### PR TITLE
Fix for Windows std::max compilation issue.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "odbc",
-  "version": "2.0.0",
+  "version": "2.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -146,7 +146,7 @@ typedef struct QueryData {
       delete[] storedRows[h];
     };
 
-    int numParameters = (std::max)(this->bindValueCount, this->parameterCount);
+    int numParameters = std::max<SQLSMALLINT>(this->bindValueCount, this->parameterCount);
 
     if (numParameters > 0) {
 

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -21,9 +21,7 @@
 
 #include <uv.h>
 #include <napi.h>
-#include <wchar.h>
-
-#include <algorithm>
+#include <wchar.h>s
 
 #include <stdlib.h>
 #ifdef dynodbc

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -23,6 +23,8 @@
 #include <napi.h>
 #include <wchar.h>
 
+#include <algorithm>
+
 #include <stdlib.h>
 #ifdef dynodbc
 #include "dynodbc.h"
@@ -144,7 +146,7 @@ typedef struct QueryData {
       delete[] storedRows[h];
     };
 
-    int numParameters = std::max(this->bindValueCount, this->parameterCount);
+    int numParameters = (std::max)(this->bindValueCount, this->parameterCount);
 
     if (numParameters > 0) {
 

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -21,7 +21,9 @@
 
 #include <uv.h>
 #include <napi.h>
-#include <wchar.h>s
+#include <wchar.h>
+
+#include <algorithm>
 
 #include <stdlib.h>
 #ifdef dynodbc


### PR DESCRIPTION
@markdirish -

Here's the fix for the compilation issue we're seeing on Windows. Specifically, I'm using Windows 10. Please let me know if this is able to be merged.

Thanks,

Ryan