### PR TITLE
Fixing both an SQL_FLOAT issue and boundRow garbage Data

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -361,13 +361,14 @@ SQLRETURN ODBC::BindColumns(QueryData *data) {
     switch(column->DataType) {
 
       case SQL_REAL:
-      case SQL_DECIMAL :
-      case SQL_NUMERIC :
+      case SQL_DECIMAL:
+      case SQL_NUMERIC:
         maxColumnLength = (column->ColumnSize + 1) * sizeof(SQLCHAR);
         targetType = SQL_C_CHAR;
         break;
 
-      case SQL_DOUBLE :
+      case SQL_FLOAT:
+      case SQL_DOUBLE:
         maxColumnLength = column->ColumnSize;
         targetType = SQL_C_DOUBLE;
         break;
@@ -433,7 +434,7 @@ SQLRETURN ODBC::FetchAll(QueryData *data) {
 
   while(SQL_SUCCEEDED(returnCode = SQLFetch(data->hSTMT))) {
 
-    ColumnData *row = new ColumnData[data->columnCount];
+    ColumnData *row = new ColumnData[data->columnCount]();
 
     // Iterate over each column, putting the data in the row object
     for (int i = 0; i < data->columnCount; i++) {
@@ -442,7 +443,7 @@ SQLRETURN ODBC::FetchAll(QueryData *data) {
       if (row[i].size == SQL_NULL_DATA) {
         row[i].data = NULL;
       } else {
-        row[i].data = new SQLCHAR[row[i].size];
+        row[i].data = new SQLCHAR[row[i].size + 1]();
         memcpy(row[i].data, data->boundRow[i], row[i].size);
       }
     }


### PR DESCRIPTION
SQL_FLOAT was not targeted to SQL_C_DOUBLE in binding the columns, instead defaulting on SQL_C_CHAR. When it came out, it was assumed to be SQL_C_DOUBLE, resulting in 8 bytes of char gibberish. Added to switch statement to fix.

For some numbers bound to SQL_C_CHAR, there would be the potential for garbage data if an additional byte wasn't added to hold a null terminator ('\0').

Fixes wankdanker#67
Fixes #8 