### PR TITLE
Update binding.gyp to fix failing build on Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -30,7 +30,8 @@
           'libraries' : [
             '-L/usr/local/lib',
             '-lodbc'
-          ]
+          ],
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
         }],
         [ 'OS=="win"', {
           'sources' : [


### PR DESCRIPTION
The build was failing on Mac because n-api exceptions were not disabled or configured