### PR TITLE
Fix array buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "odbc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -872,9 +872,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "http://github.com/markdirish/node-odbc/",
   "main": "./lib/odbc.js",
   "repository": {

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -443,8 +443,14 @@ Napi::Array ODBC::ProcessDataForNapi(Napi::Env env, QueryData *data) {
           case SQL_BINARY :
           case SQL_VARBINARY :
           case SQL_LONGVARBINARY :
-            value = Napi::ArrayBuffer::New(env, storedRow[j].data, storedRow[j].size);
+          {
+            SQLCHAR *binaryData = new SQLCHAR[storedRow[j].size]; // have to save the data on the heap
+            memcpy((SQLCHAR *) binaryData, storedRow[j].data, storedRow[j].size);
+            value = Napi::ArrayBuffer::New(env, binaryData, storedRow[j].size, [](Napi::Env env, void* finalizeData) {
+              delete[] (SQLCHAR*)finalizeData;
+            });
             break;
+          }
           // Napi::String (char16_t)
           case SQL_WCHAR :
           case SQL_WVARCHAR :


### PR DESCRIPTION
Giving ArrayBuffer data a finalizerCallback, data should remain valid until ArrayBuffer goes out of scope.

Bump to version 2.1.1