### PR TITLE
Redo errors

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -194,7 +194,7 @@ ODBCError* ODBCAsyncWorker::GetODBCErrors
   );
 
   // Windows seems to define SQLINTEGER as long int, unixodbc as just int... %i should cover both
-  DEBUG_PRINTF("ODBC::GetSQLError : called SQLGetDiagField; ret=%i, statusRecCount=%i\n", ret, statusRecCount);
+  DEBUG_PRINTF("ODBC::GetSQLError : called SQLGetDiagField; ret=%i, statusRecCount=%i\n", returnCode, statusRecCount);
 
   ODBCError *odbcErrors = new ODBCError[statusRecCount]();
   this->errorCount = statusRecCount;

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -59,9 +59,15 @@ static const std::string RETURN = "return";
 static const std::string COUNT = "count";
 static const std::string COLUMNS = "columns";
 
+typedef struct ODBCError {
+  SQLCHAR    *state;
+  SQLINTEGER  code;
+  SQLCHAR    *message;
+} ODBCError;
+
 typedef struct Column {
   SQLUSMALLINT  index;
-  SQLTCHAR      *ColumnName = NULL;
+  SQLTCHAR     *ColumnName = NULL;
   SQLSMALLINT   BufferLength;
   SQLSMALLINT   NameLength;
   SQLSMALLINT   DataType;
@@ -213,8 +219,8 @@ class ODBC {
 
     static Napi::Value Init(Napi::Env env, Napi::Object exports);
 
-    static std::string GetSQLError(SQLSMALLINT handleType, SQLHANDLE handle);
-    static std::string GetSQLError(SQLSMALLINT handleType, SQLHANDLE handle, const char* message);
+    static ODBCError GetSQLError(SQLSMALLINT handleType, SQLHANDLE handle);
+    static ODBCError GetSQLError(SQLSMALLINT handleType, SQLHANDLE handle, const char* message);
 
     static SQLTCHAR* NapiStringToSQLTCHAR(Napi::String string);
 
@@ -246,12 +252,11 @@ class ODBC {
 #endif
 
 
-#define ASYNC_WORKER_CHECK_CODE_SET_ERROR_RETURN(returnCode, handletype, handle, context, sqlFunction) \
+#define ASYNC_WORKER_CHECK_CODE_SET_ERROR_RETURN(returnCode, handleType, handle) \
 {\
   if(!SQL_SUCCEEDED(returnCode)) {\
-    char errorString[255];\
-    sprintf(errorString, "[Node.js::odbc] %s: Error in ODBC function %s", context, sqlFunction);\
-    SetError(ODBC::GetSQLError(handletype, handle, errorString));\
+    this->error = ODBC::GetSQLError(handleType, handle);\
+    SetError("");\
     return;\
   }\
 }

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -254,15 +254,4 @@ class ODBCAsyncWorker : public Napi::AsyncWorker {
 #define DEBUG_TPRINTF(...) (void)0
 #endif
 
-#define ASYNC_ERROR_CHECK(returnCode, handletype, handle, message) \
-{\
-  if (CheckAndHandleErrors(\
-    sqlReturnCode,\
-    handletype,\
-    handle,\
-    message\
-    ))\
-    { return; }\
-}
-
 #endif

--- a/src/odbc_statement.h
+++ b/src/odbc_statement.h
@@ -27,8 +27,8 @@ class ODBCStatement : public Napi::ObjectWrap<ODBCStatement> {
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
     ODBCConnection *odbcConnection;
-    // SQLHENV hENV;
-    // SQLHDBC hDBC;
+    SQLHENV hENV;
+    SQLHDBC hDBC;
     QueryData *data;
 
     SQLRETURN Free();

--- a/src/odbc_statement.h
+++ b/src/odbc_statement.h
@@ -27,8 +27,6 @@ class ODBCStatement : public Napi::ObjectWrap<ODBCStatement> {
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
     ODBCConnection *odbcConnection;
-    SQLHENV hENV;
-    SQLHDBC hDBC;
     QueryData *data;
 
     SQLRETURN Free();

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 
 const odbc = require('../');
 
-const TABLE_EXISTS_STATE = '42S01';
+const OBJECTS_EXISTS_STATE = -601;
 
 describe('odbc', () => {
   before(async () => {
@@ -12,9 +12,7 @@ describe('odbc', () => {
       connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
       await connection.query(`CREATE TABLE ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}(ID INTEGER, NAME VARCHAR(24), AGE INTEGER)`);
     } catch (error) {
-      const errorJSON = JSON.parse(`{${error.message}}`);
-      const sqlState = errorJSON.errors[0].SQLState;
-      if (sqlState !== TABLE_EXISTS_STATE) {
+      if (error.odbcErrors[0].code !== OBJECTS_EXISTS_STATE) {
         throw (error);
       }
     } finally {


### PR DESCRIPTION
* Redo how errors are returned by adding an odbcErrors array. This array has objects that have 3 fields: state, code, and message. The state is the SQL State that ODBC returns, while the code and message are from the driver.
* Add the ability to return data from fetching with arrays instead of just objects
* Added a ton of DEBUG messages