### PR TITLE
Fixing a seg fault and improving the Pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.2.1] - 2019-09-13
+### Fixed
+- pool.query() now closes the connections after query
+- Closing queries rapidly no longer causes segfaults
+
 ## [2.2.0] - 2019-08-28
 ### Added
 - Added `CHANGELONG.md`

--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,7 @@
             '-L/usr/local/lib',
             '-lodbc'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
         }],
         [ 'OS=="win"', {
           'sources' : [
@@ -42,7 +42,7 @@
           'libraries' : [
             '-lodbccp32.lib'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
         }],
         [ 'OS=="aix"', {
           'variables': {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -119,20 +119,22 @@ class Pool {
       connection = this.freeConnections.pop();
     }
 
+    if (!connection) {
+      return callback(Error('Could not get a connection from the pool.'));
+    }
+
     // promise...
     if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         connection.query(sql, parameters, (error, result) => {
           // after running, close the connection whether error or not
-          connection.close(() => {
-            this.increasePoolSize(1);
-          });
-
           if (error) {
             reject(new Error(error));
           } else {
             resolve(result);
           }
+          connection.close();
+          this.increasePoolSize(1);
         });
       });
     }
@@ -140,10 +142,11 @@ class Pool {
     // ...or callback
     return connection.query(sql, parameters, (error, result) => {
       // after running, close the connection whether error or not
-      callback(error, result);
-      // TODO: This is creating all sorts of fun segfaults!
-      // connection.close();
-      return undefined;
+      process.nextTick(() => {
+        callback(error, result);
+      });
+      connection.close();
+      this.increasePoolSize(1);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "homepage": "http://github.com/markdirish/node-odbc/",
   "main": "./lib/odbc.js",
   "repository": {


### PR DESCRIPTION
When really hammering the Pool, occasionally the CloseAsyncWorker would be called before the QueryAsyncWorker destructor, which would call a segfault. Did a check that the connection handle is not `SQL_NULL_HANDLE` before freeing the statement handles.