### PR TITLE
2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.2.2] - 2019-10-27
+### Fixed
+- Fixed SQL_DECIMAL, SQL_REAL, and SQL_NUMERIC losing precision
+
 ## [2.2.1] - 2019-09-13
 ### Fixed
 - pool.query() now closes the connections after query

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "homepage": "http://github.com/markdirish/node-odbc/",
   "main": "./lib/odbc.js",
   "repository": {

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1983,7 +1983,7 @@ SQLRETURN ODBCConnection::BindColumns(QueryData *data) {
       case SQL_REAL:
       case SQL_DECIMAL:
       case SQL_NUMERIC:
-        maxColumnLength = (column->ColumnSize + 1) * sizeof(SQLCHAR);
+        maxColumnLength = (column->ColumnSize + 2) * sizeof(SQLCHAR);
         targetType = SQL_C_CHAR;
         break;
 
@@ -1992,6 +1992,7 @@ SQLRETURN ODBCConnection::BindColumns(QueryData *data) {
         maxColumnLength = column->ColumnSize;
         targetType = SQL_C_DOUBLE;
         break;
+        
       case SQL_TINYINT:
       case SQL_SMALLINT:
       case SQL_INTEGER:


### PR DESCRIPTION
When calling `SQLBindColumn` with `SQL_REAL`, `SQL_NUMERIC` and `SQL_DECIMAL`, the value is bound to `SQL_C_CHAR`. The buffer size was set to the ColumnSize + 1 (for the null terminator), but should be set to ColumnSize +2 (for the null terminator + the decimal point). 

Fixes #42 