### PR TITLE
Update READ.me to correct select documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Run a query on the database. Can be passed an SQL string with parameter markers 
 
 ```JavaScript
 const odbc = require('odbc');
-const connection = odbc.connect(connectionString (error, connection) => {
+const connection = odbc.connect(connectionString, (error, connection) => {
     connection.query('SELECT * FROM QIWS.QCUSTCDT', (error, result) => {
         if (error) { console.error(error) }
         console.log(result);


### PR DESCRIPTION
odbc.connect(connectionString (error, connection) .... is missing a comma.
It should be odbc.connect(connectionString, (error, connection)