### PR TITLE
Fix SQL_TYPE_DATE and SQL_TYPE_TIME support

### DIFF
--- a/src/odbc.h
+++ b/src/odbc.h
@@ -72,6 +72,7 @@ typedef struct Column {
   SQLSMALLINT   DecimalDigits;
   SQLLEN        StrLen_or_IndPtr;
   SQLSMALLINT   Nullable;
+  SQLLEN        MaxColumnLength;
 } Column;
 
 // Amalgamation of the information returned by SQLDescribeParam and


### PR DESCRIPTION
There is an issue with 4D database (don't know if the issue existe with another database engine) :

The function SQLDescribeCol return an invalid column size (6 caracters) when the column type is SQL_TYPE_DATE or SQL_TYPE_TIME. 

**But** according to this documentation : https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/column-size?view=sql-server-ver15 the column size is 10 (ex: dd/mm/yyyy or yyyy-mm-dd) 
**But** in fact, the column size is 16 (dd/mm/yyyy hh:MM) 16bits per caracter (SQLWCHAR).

So, this pach force the column to have a size of 16 caracters. Also, the maxColumnSize is stored in column properties to avoid overflow in function FetchAll.

