### PR TITLE
Fix missing Statement odbcErrors when an error is thrown async

### DIFF
--- a/lib/Statement.js
+++ b/lib/Statement.js
@@ -20,7 +20,7 @@ class Statement {
       return new Promise((resolve, reject) => {
         this.odbcStatement.prepare(sql, (error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -49,7 +49,7 @@ class Statement {
       return new Promise((resolve, reject) => {
         this.odbcStatement.bind(parameters, (error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -74,7 +74,7 @@ class Statement {
       return new Promise((resolve, reject) => {
         this.odbcStatement.execute((error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -100,7 +100,7 @@ class Statement {
       return new Promise((resolve, reject) => {
         this.odbcStatement.close((error) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve();
           }


### PR DESCRIPTION
Fix missing Statement odbcErrors detail when an error is thrown asynchronously (matches callback errors). Prior to the fix, Statement errors that are thrown using `async` inadvertently remove vital `odbcErrors` that are included when using their _callback_ counterparts.