### PR TITLE
[2.3.0] Fix 'new Error'

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -111,7 +111,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.callProcedure(catalog, schema, name, parameters, (error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -139,7 +139,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.createStatement((error, odbcStatement) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             const statement = new Statement(odbcStatement);
             resolve(statement);
@@ -175,7 +175,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.close((error) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve();
           }
@@ -194,7 +194,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.columns(catalog, schema, table, type, (error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -214,7 +214,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.tables(catalog, schema, table, type, (error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -234,7 +234,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.setIsolationLevel(isolationLevel, (error) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve();
           }
@@ -257,7 +257,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.beginTransaction((error, result) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -278,7 +278,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.commit((error) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve();
           }
@@ -298,7 +298,7 @@ class Connection {
       return new Promise((resolve, reject) => {
         this.odbcConnection.rollback((error) => {
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve();
           }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -66,7 +66,7 @@ class Pool {
         return new Promise((resolve, reject) => {
           connection.nativeClose((error, result) => {
             if (error) {
-              reject(new Error(error));
+              reject(error);
             } else {
               resolve(result);
             }
@@ -129,7 +129,7 @@ class Pool {
         connection.query(sql, parameters, (error, result) => {
           // after running, close the connection whether error or not
           if (error) {
-            reject(new Error(error));
+            reject(error);
           } else {
             resolve(result);
           }
@@ -189,7 +189,7 @@ class Pool {
             await this.increasePoolSize(this.initialSize);
             resolve(null);
           } catch (error) {
-            reject(new Error(error));
+            reject(error);
           }
         });
       }


### PR DESCRIPTION
Calling `new Error()` in JavaScript around the error passed from N-API causes all of the information to be lost except the `message` property. We want to retain the `odbcErrors` property that holds an array of ODBC diagnostic records. Simply need to reject with the error returned from N-API instead of wrapping in a `new` call.