### PR TITLE
2.3.0 fix actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,52 +19,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci --production
-    - name: Package Binary
-      run: ./node_modules/.bin/node-pre-gyp package
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: binaries
-        path: build/stage/*.tar.gz
-
-  build-ubuntu:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci --production
-    - name: Package Binary
-      run: ./node_modules/.bin/node-pre-gyp package
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: binaries
-        path: build/stage/*.tar.gz
-
-  build-macos:
-
-    runs-on: macos-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+    - run: npm install -g node-gyp
     - run: npm ci --production
     - name: Package Binary
       run: ./node_modules/.bin/node-pre-gyp package
@@ -78,7 +33,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [build-windows, build-ubuntu, build-macos]
+    needs: [build-windows]
 
     steps:
 
@@ -105,62 +60,12 @@ jobs:
 
     # Upload the various binaries
 
-    - name: Upload Darwin v64
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-node-v64-darwin-x64.tar.gz
-        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-node-v64-darwin-x64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload Darwin v72
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-node-v72-darwin-x64.tar.gz
-        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-node-v72-darwin-x64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload Win32 v64
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-node-v64-win32-x64.tar.gz
-        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-node-v64-win32-x64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload Win32 v72
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-node-v72-win32-x64.tar.gz
-        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-node-v72-win32-x64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload Linux v64
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-node-v64-linux-x64.tar.gz
-        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-node-v64-linux-x64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload Linux v72
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-node-v72-linux-x64.tar.gz
-        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-node-v72-linux-x64.tar.gz
+        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
         asset_content_type: application/gzip

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 a.out
-build
 node_modules
 deps
 .idea
 core
 .env
 .vscode
+build*
+lib/bindings

--- a/binding.gyp
+++ b/binding.gyp
@@ -58,6 +58,17 @@
           ]
         }]
       ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
     }
   ]
 }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -1,6 +1,12 @@
 const async = require('async');
-const odbc = require('../build/Release/odbc.node');
+const binary = require('node-pre-gyp');
+const path = require('path');
+
 const { Connection } = require('./Connection');
+
+const bindingPath = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+
+const odbc = require(bindingPath);
 
 const INITIAL_SIZE_DEFAULT = 10;
 const INCREMENT_SIZE_DEFAULT = 10;

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -1,4 +1,10 @@
-const nativeOdbc = require('../build/Release/odbc.node');
+const binary = require('node-pre-gyp');
+const path = require('path');
+
+const bindingPath = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+
+const nativeOdbc = require(bindingPath);
+
 const { Connection } = require('./Connection');
 const { Pool } = require('./Pool');
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=8.16.0"
   },
   "scripts": {
-    "install": "node-gyp configure build",
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "mocha --slow 5000 --timeout 10000"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,11 @@
   },
   "binary": {
     "module_name": "odbc",
-    "module_path": "./build/Release/",
-    "host": "https://github.com/markdirish/node-odbc/releases/download/v{version}"
+    "module_path": "./lib/bindings/napi-v{napi_build_version}",
+    "host": "https://github.com/markdirish/node-odbc/releases/download/v{version}",
+    "package_name": "{name}-v{version}-{platform}-{arch}-napi-v{napi_build_version}.tar.gz",
+    "napi_versions": [
+      3
+    ]
   }
 }


### PR DESCRIPTION
`node-pre-gyp` has the capability to build binaries that target N-API versions (which are ABI stable), and not Node ABI versions. In order to take advantage of all of that, we have to change how the binaries are bound and required in the .js files, how they are built, and how they are declared in `package.json`. To the end user, everything should remain the same, there are just a few extra steps along the way.

This will allow binaries to be built for operating systems / architectures / N-API versions, and then during the install process it will attempt to find appropriate binaries for the system on the GitHub page's release artifacts.