### PR TITLE
Fix endian bug in stored procedure output parms

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1051,7 +1051,7 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
       for (int i = 0; i < data->parameterCount; i++) {
         data->parameters[i]->InputOutputType = data->storedRows[i][SQLPROCEDURECOLUMNS_COLUMN_TYPE_INDEX].smallint_data;
         data->parameters[i]->ParameterType = data->storedRows[i][SQLPROCEDURECOLUMNS_DATA_TYPE_INDEX].smallint_data; // DataType -> ParameterType
-        data->parameters[i]->ColumnSize = data->storedRows[i][SQLPROCEDURECOLUMNS_COLUMN_SIZE_INDEX].smallint_data; // ParameterSize -> ColumnSize
+        data->parameters[i]->ColumnSize = data->storedRows[i][SQLPROCEDURECOLUMNS_COLUMN_SIZE_INDEX].integer_data; // ParameterSize -> ColumnSize
         data->parameters[i]->Nullable = data->storedRows[i][SQLPROCEDURECOLUMNS_NULLABLE_INDEX].smallint_data;
 
         if (data->parameters[i]->InputOutputType == SQL_PARAM_OUTPUT) {


### PR DESCRIPTION
When calling stored procedures with output parameters, the output is
always blank. This is due to using the wrong size field when querying
SQLProcedureColumns to retrieve the column size for each parameter. This
field is defined by ODBC as an INTEGER, but the pointer is read from a
SMALLINT instead. This results in the size being read from only the top
2 bytes of the 4 byte value. On little endian systems, this will be OK
so long as the size is < 32k. On big endian systems it will always be 0
unless the size is > 32k or negative; regardless it will always be
*wrong*.

Fixes #103