### PR TITLE
[Enhancement] Build Windows with UNICODE

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -42,7 +42,7 @@
           'libraries' : [
             '-lodbccp32.lib'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL', 'UNICODE' ]
         }],
         [ 'OS=="aix"', {
           'variables': {


### PR DESCRIPTION
Update binding.gyp to build Windows with UNICODE defined by default