### PR TITLE
[Fix] Make GitHub Actions build from source

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci --production
+    - run: npm ci --production --build-from-source
 
   build-ubuntu:
 
@@ -33,7 +33,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci --production
+    - run: npm ci --production --build-from-source
 
   build-macos:
 
@@ -49,4 +49,4 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci --production
+    - run: npm ci --production --build-from-source


### PR DESCRIPTION
When prebuilt binaries exist, ensure that the workflow builds the PR from source