### PR TITLE
[Fix] Ensure NUMERICS return correct values

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -350,7 +350,6 @@ Napi::Array ODBCConnection::ProcessDataForNapi(Napi::Env env, QueryData *data, N
                 value = Napi::Number::New(env, storedRow[j].double_data);
                 break;
               default:
-                printf("Stored row: %s\n", (const char*)storedRow[j].char_data);
                 value = Napi::Number::New(env, atof((const char*)storedRow[j].char_data));
                 break;
               break;

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -350,6 +350,7 @@ Napi::Array ODBCConnection::ProcessDataForNapi(Napi::Env env, QueryData *data, N
                 value = Napi::Number::New(env, storedRow[j].double_data);
                 break;
               default:
+                printf("Stored row: %s\n", (const char*)storedRow[j].char_data);
                 value = Napi::Number::New(env, atof((const char*)storedRow[j].char_data));
                 break;
               break;
@@ -2181,14 +2182,17 @@ SQLRETURN ODBCConnection::FetchAll(QueryData *data) {
 
         case SQL_C_WCHAR:
           row[i].size = strlen16((const char16_t *)data->boundRow[i]);
-          row[i].wchar_data = new SQLWCHAR[row[i].size];
+          row[i].wchar_data = new SQLWCHAR[row[i].size]();
           memcpy(row[i].wchar_data, data->boundRow[i], row[i].size * sizeof(SQLWCHAR));
           break;
 
         case SQL_C_CHAR:
         default:
           row[i].size = strlen((const char *)data->boundRow[i]);
-          row[i].char_data = new SQLCHAR[row[i].size];
+          // Although fields going from SQL_C_CHAR to Napi::String use
+          // row[i].size, NUMERIC data uses atof() which requires a
+          // null terminator. Need to add an aditional byte.
+          row[i].char_data = new SQLCHAR[row[i].size + 1]();
           memcpy(row[i].char_data, data->boundRow[i], row[i].size);
           break;
 


### PR DESCRIPTION
When moving from boundRow to storedRow, add space for null-terminator for SQL_C_CHAR bindings so atof() works

Fixes #96 