### PR TITLE
[Fix] Fix UNICODE string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "odbc",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "homepage": "http://github.com/markdirish/node-odbc/",
   "main": "lib/odbc.js",
   "types": "lib/odbc.d.ts",

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -150,7 +150,11 @@ void ODBCAsyncWorker::OnError(const Napi::Error &e) {
 
     errorObject.Set(
       Napi::String::New(env, STATE),
+      #ifdef UNICODE
+      Napi::String::New(env, (const char16_t*)odbcError.state)
+      #else
       Napi::String::New(env, (const char*)odbcError.state)
+      #endif
     );
     errorObject.Set(
       Napi::String::New(env, CODE),
@@ -158,7 +162,11 @@ void ODBCAsyncWorker::OnError(const Napi::Error &e) {
     );
     errorObject.Set(
       Napi::String::New(env, MESSAGE),
+      #ifdef UNICODE
+      Napi::String::New(env, (const char16_t*)odbcError.message)
+      #else
       Napi::String::New(env, (const char*)odbcError.message)
+      #endif
     );
 
     odbcErrors.Set(i, errorObject);

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -315,7 +315,11 @@ Napi::Array ODBCConnection::ProcessDataForNapi(Napi::Env env, QueryData *data, N
 
   for (SQLSMALLINT h = 0; h < columnCount; h++) {
     Napi::Object column = Napi::Object::New(env);
+    #ifdef UNICODE
+    column.Set(Napi::String::New(env, NAME), Napi::String::New(env, (const char16_t*)columns[h]->ColumnName));
+    #else
     column.Set(Napi::String::New(env, NAME), Napi::String::New(env, (const char*)columns[h]->ColumnName));
+    #endif
     column.Set(Napi::String::New(env, DATA_TYPE), Napi::Number::New(env, columns[h]->DataType));
     column.Set(Napi::String::New(env, COLUMN_SIZE), Napi::Number::New(env, columns[h]->ColumnSize));
     column.Set(Napi::String::New(env, DECIMAL_DIGITS), Napi::Number::New(env, columns[h]->DecimalDigits));


### PR DESCRIPTION
If UNICODE is defined, have result.columns.name use char16_t
If UNICODE is defined, have error.state and error.code use char16_t

Fixes #112 