### PR TITLE
[Fix] Improve pooling with EventEmitter and counting active connection attempts

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -68,7 +68,9 @@ class Connection {
       });
     }
 
-    return this.odbcConnection.query(sql, parameters, callback);
+    process.nextTick(() => {
+      this.odbcConnection.query(sql, parameters, callback);
+    })
   }
 
   /**

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -100,7 +100,10 @@ class Pool {
 
     if (this.freeConnections.length == 0) {
 
-      if (this.connectingCount == 0)
+      // If the number of connections waiting is more (shouldn't happen) or
+      // equal to the number of connections connecting, then we will need to
+      // create MORE connections.
+      if (this.connectingCount <= this.connectionQueue.length)
       {
         this.increasePoolSize(this.incrementSize);
       }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -1,3 +1,4 @@
+const EventEmitter = require('events');
 const async = require('async');
 const binary = require('node-pre-gyp');
 const path = require('path');
@@ -17,9 +18,31 @@ const CONNECTION_TIMEOUT_DEFAULT = 0;
 const LOGIN_TIMEOUT_DEFAULT = 0;
 
 class Pool {
+
   constructor(connectionString) {
+
+    this.connectionEmitter = new EventEmitter();
+    this.connectionEmitter.on('connected', (connection) => {
+      if (this.connectionQueue.length > 0)
+      {
+        let connectionWork = this.connectionQueue.pop();
+        if (typeof connectionWork == 'function')
+        {
+          // callback function
+          return connectionWork(null, connection);
+        } else {
+          // Promise (stored resolve function)
+          return connectionWork.resolveFunction(connection);
+        }
+      } else {
+        this.freeConnections.push(connection);
+      }
+    });
+
     this.isOpen = false;
     this.freeConnections = [];
+    this.connectingCount = 0;
+    this.connectionQueue = [];
 
     // connectionString is a...
     if (typeof connectionString === 'string') {
@@ -40,17 +63,31 @@ class Pool {
       }
       this.connectionString = configObject.connectionString;
 
-      this.reuseConnections = configObject.reuseConnections || REUSE_CONNECTIONS_DEFAULT;
-      this.initialSize = configObject.initialSize || INITIAL_SIZE_DEFAULT;
-      this.incrementSize = configObject.incrementSize || INCREMENT_SIZE_DEFAULT;
-      this.maxSize = configObject.maxSize || MAX_SIZE_DEFAULT;
-      this.shrink = configObject.shrink || SHRINK_DEFAULT;
-      this.connectionTimeout = configObject.connectionTimeout || CONNECTION_TIMEOUT_DEFAULT;
-      this.loginTimeout = configObject.loginTimeout || LOGIN_TIMEOUT_DEFAULT;
+      // reuseConnections
+      this.reuseConnections = configObject.reuseConnections !== undefined ? configObject.reuseConnections : REUSE_CONNECTIONS_DEFAULT;
+
+      // initialSize
+      this.initialSize = configObject.initialSize !== undefined ? configObject.initialSize : INITIAL_SIZE_DEFAULT;
+
+      // incrementSize
+      this.incrementSize = configObject.incrementSize !== undefined ? configObject.incrementSize : INCREMENT_SIZE_DEFAULT;
+
+      // maxSize
+      this.maxSize = configObject.incrementSize !== undefined ? configObject.incrementSize : INCREMENT_SIZE_DEFAULT;
+
+      // shrink
+      this.shrink = configObject.shrink !== undefined ? configObject.shrink : SHRINK_DEFAULT;
+
+      // connectionTimeout
+      this.connectionTimeout = configObject.connectionTimeout !== undefined ? configObject.connectionTimeout : CONNECTION_TIMEOUT_DEFAULT;
+
+      // loginTimeout
+      this.loginTimeout = configObject.loginTimeout !== undefined ? configObject.loginTimeout : LOGIN_TIMEOUT_DEFAULT;
     } else {
       throw TypeError('Pool constructor must passed a connection string or a configuration object');
     }
   }
+
 
   // TODO: Documentation
   // TODO: Does this need to be async?
@@ -58,25 +95,43 @@ class Pool {
   // should overwrite the 'close' function of the connection, and rename it is 'nativeClose', so
   // that that close can still be called.
   async connect(callback = undefined) {
+
+    let connection;
+
     if (this.freeConnections.length == 0) {
-      await this.increasePoolSize(this.incrementSize);
-    }
 
-    let connection = this.freeConnections.pop();
+      if (this.connectingCount == 0)
+      {
+        this.increasePoolSize(this.incrementSize);
+      }
 
-    // promise...
-    if (typeof callback === 'undefined') {
-      return new Promise((resolve, reject) => {
-        if (connection == null) {
-          reject();
-        } else {
-          resolve(connection);
+      if (typeof callback == 'undefined') {
+        let resolveConnectionPromise;
+
+        const promise = new Promise((resolve, reject) => {
+          resolveConnectionPromise = resolve;
+        });
+        const promiseObj = {
+          promise: promise,
+          resolveFunction: resolveConnectionPromise
         }
-      });
-    }
+        this.connectionQueue.unshift(promiseObj);
+        return promise;
+      } else {
+        this.connectionQueue.unshift(callback)
+        return undefined;
+      }
+    } else {
+      connection = this.freeConnections.pop();
 
-    // ...or callback
-    return callback(null, connection);
+      // promise...
+      if (typeof callback === 'undefined') {
+        return Promise.resolve(connection);
+      } else {
+        // ...or callback
+        return callback(null, connection);
+      }
+    }
   };
 
   async query(sql, params, cb) {
@@ -93,41 +148,38 @@ class Pool {
       } // else parameters = params, check type in this.ODBCconnection.query
     }
 
-    let connection;
-
-    if (this.freeConnections.length > 0) {
-      connection = this.freeConnections.pop();
-    } else {
-      await this.increasePoolSize(this.incrementSize);
-      connection = this.freeConnections.pop();
-    }
-
-    if (!connection) {
-      return callback(Error('Could not get a connection from the pool.'));
-    }
-
-    // promise...
     if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
-        connection.query(sql, parameters, (error, result) => {
-          // after running, close the connection whether error or not
+        this.connect((error, connection) => {
           if (error) {
             reject(error);
-          } else {
-            resolve(result);
           }
-          connection.close();
+
+          connection.query(sql, parameters, (error, result) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(result);
+            }
+            connection.close();
+          });
         });
       });
     }
 
-    // ...or callback
-    return connection.query(sql, parameters, (error, result) => {
-      // after running, close the connection whether error or not
-      process.nextTick(() => {
-        callback(error, result);
+    this.connect((error, connection) => {
+      if (error) {
+        throw error;
+      }
+
+      // ...or callback
+      return connection.query(sql, parameters, (error, result) => {
+        // after running, close the connection whether error or not
+        process.nextTick(() => {
+          callback(error, result);
+        });
+        connection.close();
       });
-      connection.close();
     });
   }
 
@@ -168,7 +220,7 @@ class Pool {
         return new Promise(async (resolve, reject) => {
           try {
             await this.increasePoolSize(this.initialSize);
-            resolve(null);
+            resolve();
           } catch (error) {
             reject(error);
           }
@@ -183,77 +235,76 @@ class Pool {
       }
       return callback(null);
     }
-
-    console.log('.init() was called, but the Pool was already initialized.');
     return undefined;
   }
 
   // odbc.connect runs on an AsyncWorker, so this is truly non-blocking
   async increasePoolSize(count) {
+    this.connectingCount += count;
     const connectionConfig = {
       connectionString: this.connectionString,
       connectionTimeout: this.connectionTimeout,
       loginTimeout: this.loginTimeout,
     };
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       const connectArray = [];
       for (let i = 0; i < count; i += 1) {
-        connectArray.push((callback) => {
+        let promise = new Promise((resolve, reject) => {
           odbc.connect(connectionConfig, (error, nativeConnection) => {
             let connection = undefined;
-            if (!error) {
-              connection = new Connection(nativeConnection);
-              if (this.isOpen) {
-                connection.nativeClose = connection.close;
-                if (this.reuseConnections) {
-                  connection.close = async (closeCallback = undefined) => {
-                    this.freeConnections.push(connection);
-
-                    if (typeof closeCallback === 'undefined') {
-                      return new Promise((resolve) => {
-                        resolve();
-                      })
-                    }
-
-                    closeCallback(null);
-                    return undefined;
-                  }
-                } else {
-                  connection.nativeClose = connection.close;
-                  connection.close = async (closeCallback = undefined) => {
-                    if (typeof closeCallback === 'undefined') {
-                      return new Promise((resolve, reject) => {
-                        connection.nativeClose((error, result) => {
-                          if (error) {
-                            reject(error);
-                          } else {
-                            resolve(result);
-                          }
-                        });
-              
-                        this.increasePoolSize(1);
-                      });
-                    }
-              
-                    connection.nativeClose(closeCallback);
-                    this.increasePoolSize(1);
-                    return undefined;
-                  }
-                }
-              }
-              this.freeConnections.push(connection);
+            if (error) {
+              reject(error);
+              return;
             }
-            callback(error, connection);
+
+            connection = new Connection(nativeConnection);
+            connection.nativeClose = connection.close;
+
+            if (this.reuseConnections) {
+              connection.close = async (closeCallback = undefined) => {
+                this.connectionEmitter.emit('connected', connection);
+
+                if (typeof closeCallback === 'undefined') {
+                  return new Promise((resolve, reject) => {
+                    resolve();
+                  })
+                }
+
+                return closeCallback(null);
+              };
+            } else {
+              connection.close = async (closeCallback = undefined) => {
+                this.increasePoolSize(1);
+                if (typeof closeCallback === 'undefined') {
+                  return new Promise((resolve, reject) => {
+                    connection.nativeClose((error, result) => {
+                      if (error) {
+                        reject(error);
+                      } else {
+                        resolve(result);
+                      }
+                    });
+                  });
+                }
+          
+                connection.nativeClose(closeCallback);
+              }
+            }
+
+            this.connectingCount--;
+            this.connectionEmitter.emit('connected', connection);
+            resolve();
           });
         });
+        connectArray.push(promise);
       }
-      async.race(connectArray, (error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
+      if (connectArray.length > 0)
+      {
+        await Promise.race(connectArray);
+        resolve();
+      } else {
+        resolve();
+      }
     });
   }
 }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -8,6 +8,7 @@ const bindingPath = binary.find(path.resolve(path.join(__dirname, '../package.js
 
 const odbc = require(bindingPath);
 
+const REUSE_CONNECTIONS_DEFAULT = true;
 const INITIAL_SIZE_DEFAULT = 10;
 const INCREMENT_SIZE_DEFAULT = 10;
 const MAX_SIZE_DEFAULT = null;
@@ -23,18 +24,23 @@ class Pool {
     // connectionString is a...
     if (typeof connectionString === 'string') {
       this.connectionString = connectionString;
+
+      this.reuseConnections = REUSE_CONNECTIONS_DEFAULT;
       this.initialSize = INITIAL_SIZE_DEFAULT;
       this.incrementSize = INCREMENT_SIZE_DEFAULT;
       this.maxSize = MAX_SIZE_DEFAULT;
       this.shrink = SHRINK_DEFAULT;
       this.connectionTimeout = CONNECTION_TIMEOUT_DEFAULT;
       this.loginTimeout = LOGIN_TIMEOUT_DEFAULT;
+
     } else if (typeof connectionString === 'object') {
       const configObject = connectionString;
       if (!Object.prototype.hasOwnProperty.call(configObject, 'connectionString')) {
         throw new TypeError('Pool configuration object must contain "connectionString" key');
       }
       this.connectionString = configObject.connectionString;
+
+      this.reuseConnections = configObject.reuseConnections || REUSE_CONNECTIONS_DEFAULT;
       this.initialSize = configObject.initialSize || INITIAL_SIZE_DEFAULT;
       this.incrementSize = configObject.incrementSize || INCREMENT_SIZE_DEFAULT;
       this.maxSize = configObject.maxSize || MAX_SIZE_DEFAULT;
@@ -52,40 +58,11 @@ class Pool {
   // should overwrite the 'close' function of the connection, and rename it is 'nativeClose', so
   // that that close can still be called.
   async connect(callback = undefined) {
-    if (this.freeConnections.length < 2) {
+    if (this.freeConnections.length == 0) {
       await this.increasePoolSize(this.incrementSize);
     }
 
-    let connection;
-
-    if (this.freeConnections.length > 0) {
-      connection = this.freeConnections.pop();
-    } else {
-      await this.increasePoolSize(this.incrementSize);
-      connection = this.freeConnections.pop();
-    }
-
-    connection.nativeClose = connection.close;
-
-    connection.close = async (closeCallback = undefined) => {
-      if (typeof closeCallback === 'undefined') {
-        return new Promise((resolve, reject) => {
-          connection.nativeClose((error, result) => {
-            if (error) {
-              reject(error);
-            } else {
-              resolve(result);
-            }
-          });
-
-          this.increasePoolSize(1);
-        });
-      }
-
-      connection.nativeClose(closeCallback);
-      this.increasePoolSize(1);
-      return undefined;
-    };
+    let connection = this.freeConnections.pop();
 
     // promise...
     if (typeof callback === 'undefined') {
@@ -100,7 +77,7 @@ class Pool {
 
     // ...or callback
     return callback(null, connection);
-  }
+  };
 
   async query(sql, params, cb) {
     // determine the parameters passed
@@ -163,7 +140,7 @@ class Pool {
     if (typeof callback === 'undefined') {
       return new Promise((resolve, reject) => {
         async.each(connections, (connection, cb) => {
-          connection.close((error) => {
+          connection.nativeClose((error) => {
             cb(error);
           });
         }, (error) => {
@@ -177,7 +154,7 @@ class Pool {
     }
 
     async.each(this.freeConnections, (connection, cb) => {
-      connection.close((error) => {
+      connection.nativeClose((error) => {
         cb(error);
       });
     }, error => callback(error));
@@ -222,11 +199,49 @@ class Pool {
       const connectArray = [];
       for (let i = 0; i < count; i += 1) {
         connectArray.push((callback) => {
-          odbc.connect(connectionConfig, (error, connection) => {
+          odbc.connect(connectionConfig, (error, nativeConnection) => {
+            let connection = undefined;
             if (!error) {
+              connection = new Connection(nativeConnection);
               if (this.isOpen) {
-                this.freeConnections.push(new Connection(connection));
+                connection.nativeClose = connection.close;
+                if (this.reuseConnections) {
+                  connection.close = async (closeCallback = undefined) => {
+                    this.freeConnections.push(connection);
+
+                    if (typeof closeCallback === 'undefined') {
+                      return new Promise((resolve) => {
+                        resolve();
+                      })
+                    }
+
+                    closeCallback(null);
+                    return undefined;
+                  }
+                } else {
+                  connection.nativeClose = connection.close;
+                  connection.close = async (closeCallback = undefined) => {
+                    if (typeof closeCallback === 'undefined') {
+                      return new Promise((resolve, reject) => {
+                        connection.nativeClose((error, result) => {
+                          if (error) {
+                            reject(error);
+                          } else {
+                            resolve(result);
+                          }
+                        });
+              
+                        this.increasePoolSize(1);
+                      });
+                    }
+              
+                    connection.nativeClose(closeCallback);
+                    this.increasePoolSize(1);
+                    return undefined;
+                  }
+                }
               }
+              this.freeConnections.push(connection);
             }
             callback(error, connection);
           });

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -34,14 +34,9 @@ function pool(options, callback) {
   const poolObj = new Pool(options);
 
   if (typeof callback !== 'function') {
-    return new Promise((resolve, reject) => {
-      poolObj.init((error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(poolObj);
-        }
-      });
+    return new Promise(async (resolve, reject) => {
+      await poolObj.init();
+      resolve(poolObj);
     });
   }
 

--- a/test/pool/close.js
+++ b/test/pool/close.js
@@ -24,6 +24,9 @@ describe('close()...', () => {
   describe('...with promises...', () => {
     it('...should close all connections in the Pool.', async () => {
       const pool = await odbc.pool(`${process.env.CONNECTION_STRING}`);
+      assert.notDeepEqual(pool, null);
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      assert.deepEqual(pool.freeConnections.length, 10);
       await pool.close();
       assert.deepEqual(pool.freeConnections.length, 0);
     });


### PR DESCRIPTION
* Improve how pooling is handled by having connections fire off a "connected" event once they have finished connecting.
* Also prevent the package from creating lots of connections if there are enough connections in the process of being created to handle the load (create new connections again when there is a backup of waiting connections).