### PR TITLE
TypeScript: Add generic type to query functions of Connection

### DIFF
--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -55,8 +55,8 @@ declare namespace odbc {
     ////////////////////////////////////////////////////////////////////////////
     //   Callbacks   ///////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
-    query(sql: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
-    query(sql: string, parameters: Array<number|string>, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
+    query<T>(sql: string, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, parameters: Array<number|string>, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
 
     callProcedure(catalog: string, schema: string, name: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
     callProcedure(catalog: string, schema: string, name: string, parameters: Array<number|string>, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
@@ -81,7 +81,7 @@ declare namespace odbc {
     //   Promises   ////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
 
-    query(sql: string, parameters?: Array<number|string>): Promise<Result<unknown>>;
+    query<T>(sql: string, parameters?: Array<number|string>): Promise<Result<T>>;
 
     callProcedure(catalog: string, schema: string, name: string, parameters?: Array<number|string>): Promise<Result<unknown>>;
 


### PR DESCRIPTION
Currently I have to do this ugly type conversion:
```ts
const result = <TABLE_SCHEMA[]><unknown>(await connection.query(stmt, items));
```
To make things easier, this pull request adds a generic T to the query functions of the Connection class.
The result is a much cleaner code:
```ts
const result = await connection.query<TABLE_SCHEMA>(stmt, items);
```