### PR TITLE
Break in the correct location to prevent fallthrough

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -366,8 +366,8 @@ Napi::Array ODBCConnection::ProcessDataForNapi(Napi::Env env, QueryData *data, N
               default:
                 value = Napi::Number::New(env, atof((const char*)storedRow[j].char_data));
                 break;
-              break;
             }
+            break;
           // Napi::Number
           case SQL_FLOAT:
           case SQL_DOUBLE:


### PR DESCRIPTION
I noticed in a warning in a recent build that lead me to identify this bug:

```
../src/odbc_connection.cpp:362:13: warning: this statement may fall through [-Wimplicit-fallthrough=]
  362 |             switch(columns[j]->bind_type) {
      |             ^~~~~~
../src/odbc_connection.cpp:372:11: note: here
  372 |           case SQL_FLOAT:
      |           ^~~~
```