### PR TITLE
Refactor: Local return codes and StatementData hSTMT -> hstmt

### DIFF
--- a/src/odbc.h
+++ b/src/odbc.h
@@ -136,7 +136,7 @@ typedef struct StatementData {
 
   SQLHENV  henv;
   SQLHDBC  hdbc;
-  SQLHSTMT hSTMT;
+  SQLHSTMT hstmt;
 
   // parameters
   SQLSMALLINT parameterCount = 0; // returned by SQLNumParams
@@ -168,7 +168,7 @@ typedef struct StatementData {
   SQLTCHAR *column    = NULL;
   SQLTCHAR *procedure = NULL;
 
-  SQLRETURN sqlReturnCode;
+  // SQLRETURN sqlReturnCode;
 
   ~StatementData() {
     this->clear();
@@ -287,8 +287,8 @@ class ODBC {
 
     static void StoreBindValues(Napi::Array *values, Parameter **parameters);
 
-    static SQLRETURN DescribeParameters(SQLHSTMT hSTMT, Parameter **parameters, SQLSMALLINT parameterCount);
-    static SQLRETURN  BindParameters(SQLHSTMT hSTMT, Parameter **parameters, SQLSMALLINT parameterCount);
+    static SQLRETURN DescribeParameters(SQLHSTMT hstmt, Parameter **parameters, SQLSMALLINT parameterCount);
+    static SQLRETURN  BindParameters(SQLHSTMT hstmt, Parameter **parameters, SQLSMALLINT parameterCount);
     static Napi::Array ParametersToArray(Napi::Env env, StatementData *data);
 
     void Free();


### PR DESCRIPTION
Quick refactor PR fixing two pet peeves I have with the `StatementData` struct:
1. There is really no need to store the return code on the data structure. Instead, create a local `SQLRETURN` variable in the `Execute()` function of the `AsyncWorker`s that can be used for any call to the ODBC API made in that thread.
2. I changed the variable names of the `SQLHENV` and `SQLHDBC` to `henv` and `hdbc` respectively. I didn't change the `SQLHSTMT` because it was more ubiquitous. I change that in this PR.

I also have "vertical-ized" or "elongated" various calls to ODBC functions. It has become much easier to see what arguments are being passed in what positions this way, and I am changing them as I encounter them.