### PR TITLE
Signed SQL_BIGINT

### DIFF
--- a/src/odbc.h
+++ b/src/odbc.h
@@ -114,7 +114,7 @@ typedef struct ColumnData {
     SQLUSMALLINT  usmallint_data;
     SQLSMALLINT   smallint_data;
     SQLINTEGER    integer_data;
-    SQLUBIGINT    ubigint_data;
+    SQLBIGINT     bigint_data;
   };
   SQLLEN    size;
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -2745,8 +2745,8 @@ bind_buffers
 
       case SQL_BIGINT:
       {
-        column->buffer_size = sizeof(SQLUBIGINT);
-        column->bind_type = SQL_C_UBIGINT;
+        column->buffer_size = sizeof(SQLBIGINT);
+        column->bind_type = SQL_C_SBIGINT;
         data->bound_columns[i].buffer =
           new SQLBIGINT[data->fetch_size]();
         break;
@@ -2877,8 +2877,8 @@ fetch_and_store
                     ((SQLINTEGER *)(data->bound_columns[column_index].buffer))[row_index];
                   break;
 
-                case SQL_C_UBIGINT:
-                  row[column_index].ubigint_data =
+                case SQL_C_SBIGINT:
+                  row[column_index].bigint_data =
                     ((SQLBIGINT *)(data->bound_columns[column_index].buffer))[row_index];
                   break;
 
@@ -3162,9 +3162,9 @@ Napi::Array process_data_for_napi(Napi::Env env, StatementData *data, Napi::Arra
           // Napi::BigInt
           case SQL_BIGINT:
             switch(columns[j]->bind_type) {
-              case SQL_C_UBIGINT:
+              case SQL_C_SBIGINT:
 #if NAPI_VERSION > 5
-                value = Napi::BigInt::New(env, (int64_t)storedRow[j].ubigint_data);
+                value = Napi::BigInt::New(env, (int64_t)storedRow[j].bigint_data);
 #else
                 value = Napi::Number::New(env, (int64_t)storedRow[j].ubigint_data);
 #endif


### PR DESCRIPTION
Issue: https://github.com/markdirish/node-odbc/issues/127

Current behavior is for SQL_BIGINT to bind to SQL_C_UBIGINT, which means that any negative big int will cause an error. Switch to binding to SQL_C_SBIGINT so signed bigints can be retrieved.

It might be good in the future to check whether types are signed or not using `[SQLGetTypeInfo`](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function?view=sql-server-ver15) and use the 'UNSIGNED_ATTRIBUTE' column, but that's a task for another day...