### PR TITLE
Issue 174: Fix wchar buffers pointing at the wrong memory locations

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -2832,7 +2832,7 @@ fetch_and_store
 
                 case SQL_C_WCHAR:
                 {
-                  SQLWCHAR *memory_start = (SQLWCHAR *)data->bound_columns[column_index].buffer + (row_index * data->columns[column_index]->ColumnSize + 1);
+                  SQLWCHAR *memory_start = (SQLWCHAR *)data->bound_columns[column_index].buffer + (row_index * (data->columns[column_index]->buffer_size / sizeof(SQLWCHAR)));
                   row[column_index].size = strlen16((const char16_t *)memory_start);
                   row[column_index].wchar_data = new SQLWCHAR[row[column_index].size + 1]();
                   memcpy


### PR DESCRIPTION
For WCHAR fields, buffer offsets were calculated incorrectly as the space for the null-terminator was added _after_ multiplication of the ColumnSize with the row index, instead of being added to the ColumnSize before.

Instead of wrapping the equation in parens, I decided to use `bufferSize`, which includes space for the null-terminator and is stored as bytes instead of 2-byte SQLWCHAR units, and simply divide it by `sizeof(SQLWCHAR)`. This makes it clearly what is actually happening (offsetting the memory location by the size of the buffer * the row you are trying to get from the buffer). It also matches the logic for `SQLCHAR` immediate below (except for the dividing by `sizeof` part).

Fixes #174 

Signed-off-by: Mark Irish <mirish@ibm.com>