### PR TITLE
Clean up connection getters/setters for timeouts

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -325,7 +325,7 @@ class ConnectAsyncWorker : public ODBCAsyncWorker {
         return_code = SQLSetConnectAttr(
           hDBC,                                   // ConnectionHandle
           SQL_ATTR_CONNECTION_TIMEOUT,            // Attribute
-          (SQLPOINTER) intptr_t(options->connectionTimeout), // ValuePtr
+          (SQLPOINTER) (intptr_t) options->connectionTimeout, // ValuePtr
           SQL_IS_UINTEGER                         // StringLength
         );
         if (!SQL_SUCCEEDED(return_code)) {
@@ -341,7 +341,7 @@ class ConnectAsyncWorker : public ODBCAsyncWorker {
         (
           hDBC,                                            // ConnectionHandle
           SQL_ATTR_LOGIN_TIMEOUT,                          // Attribute
-          (SQLPOINTER) intptr_t(options->loginTimeout), // ValuePtr
+          (SQLPOINTER) (intptr_t) options->loginTimeout, // ValuePtr
           SQL_IS_UINTEGER                                  // StringLength
         );
         if (!SQL_SUCCEEDED(return_code)) {

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -64,8 +64,8 @@ Napi::Object ODBCConnection::Init(Napi::Env env, Napi::Object exports) {
 
     InstanceAccessor("connected", &ODBCConnection::ConnectedGetter, nullptr),
     InstanceAccessor("autocommit", &ODBCConnection::AutocommitGetter, nullptr),
-    InstanceAccessor("connectionTimeout", &ODBCConnection::ConnectTimeoutGetter, &ODBCConnection::ConnectTimeoutSetter),
-    InstanceAccessor("loginTimeout", &ODBCConnection::LoginTimeoutGetter, &ODBCConnection::LoginTimeoutSetter)
+    InstanceAccessor("connectionTimeout", &ODBCConnection::ConnectionTimeoutGetter, nullptr),
+    InstanceAccessor("loginTimeout", &ODBCConnection::LoginTimeoutGetter, nullptr)
 
   });
 
@@ -172,9 +172,6 @@ ODBCConnection::ODBCConnection(const Napi::CallbackInfo& info) : Napi::ObjectWra
   this->connectionOptions = *(info[2].As<Napi::External<ConnectionOptions>>().Data());
   this->maxColumnNameLength = *(info[3].As<Napi::External<SQLSMALLINT>>().Data());
   this->availableIsolationLevels = *(info[4].As<Napi::External<SQLUINTEGER>>().Data());
-
-  this->connectionTimeout = 0;
-  this->loginTimeout = 5;
 }
 
 ODBCConnection::~ODBCConnection() {
@@ -211,40 +208,22 @@ Napi::Value ODBCConnection::ConnectedGetter(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, false);
 }
 
-Napi::Value ODBCConnection::ConnectTimeoutGetter(const Napi::CallbackInfo& info) {
+Napi::Value ODBCConnection::ConnectionTimeoutGetter(const Napi::CallbackInfo& info)
+{
 
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  return Napi::Number::New(env, this->connectionTimeout);
+  return Napi::Number::New(env, this->connectionOptions.connectionTimeout);
 }
 
-void ODBCConnection::ConnectTimeoutSetter(const Napi::CallbackInfo& info, const Napi::Value& value) {
+Napi::Value ODBCConnection::LoginTimeoutGetter(const Napi::CallbackInfo& info)
+{
 
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  if (value.IsNumber()) {
-    this->connectionTimeout = value.As<Napi::Number>().Uint32Value();
-  }
-}
-
-Napi::Value ODBCConnection::LoginTimeoutGetter(const Napi::CallbackInfo& info) {
-
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
-  return Napi::Number::New(env, this->loginTimeout);
-}
-
-void ODBCConnection::LoginTimeoutSetter(const Napi::CallbackInfo& info, const Napi::Value& value) {
-
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
-  if (value.IsNumber()) {
-    this->loginTimeout = value.As<Napi::Number>().Uint32Value();
-  }
+  return Napi::Number::New(env, this->connectionOptions.loginTimeout);
 }
 
 /******************************************************************************

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -76,13 +76,8 @@ class ODBCConnection : public Napi::ObjectWrap<ODBCConnection> {
 
   // Property Getter/Setterss
   Napi::Value ConnectedGetter(const Napi::CallbackInfo& info);
-
-  Napi::Value ConnectTimeoutGetter(const Napi::CallbackInfo& info);
-  void ConnectTimeoutSetter(const Napi::CallbackInfo& info, const Napi::Value &value);
-
+  Napi::Value ConnectionTimeoutGetter(const Napi::CallbackInfo& info);
   Napi::Value LoginTimeoutGetter(const Napi::CallbackInfo& info);
-  void LoginTimeoutSetter(const Napi::CallbackInfo& info, const Napi::Value &value);
-
   Napi::Value AutocommitGetter(const Napi::CallbackInfo& info);
 
   Napi::Value GetInfo(const Napi::Env env, const SQLUSMALLINT option);
@@ -96,9 +91,6 @@ class ODBCConnection : public Napi::ObjectWrap<ODBCConnection> {
 
   SQLHENV hENV;
   SQLHDBC hDBC;
-
-  SQLUINTEGER connectionTimeout;
-  SQLUINTEGER loginTimeout;
 
   ConnectionOptions connectionOptions;
 


### PR DESCRIPTION
For whatever reason, `connection.loginTimeout` had a getter _and_ a setter, when it needs to be set prior to connecting. Removed the setter, and also ensured that the getter returns whatever value was either set in the connection options, or if the driver has decided to change the option, the value that the driver changed it to.

I also removed the `connection.connectionTimeout` setter. It wasn't actually _doing_ anything, and although setting the connection timeout after connecting makes sense and is allowed, I'm not sure how best to handle the async nature of setting a new value in relation to JavaScript properties. Might need to implement a setter that is a function:

```
connection.setConnectionTimeout(value, callback?);
```
or maybe a generic one?
```
connection.setConnectionAttribute(attribute, value, callback?);
```