### PR TITLE
Fix pool connection-creation blocking queries

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -27,19 +27,16 @@ class ConnectionQueue
 
   static enqueue = async function(pool, promiseGenerator, configObject)
   {
-    return new Promise((resolve, reject) => {
       ConnectionQueue.queuedConnections.push({
           pool,
           promiseGenerator,
-          configObject,
-          resolve,
-          reject,
+          configObject
       });
       ConnectionQueue.dequeue();
-    });
+      return;
   }
 
-  static dequeue = function()
+  static dequeue = async function()
   {
     if (this.activelyConnectingCount >= this.maxActivelyConnecting) {
       return false;
@@ -50,20 +47,11 @@ class ConnectionQueue
     }
     try {
       ConnectionQueue.activelyConnectingCount++;
-      item.promiseGenerator(item.configObject)
-        .then((value) => {
-          ConnectionQueue.activelyConnectingCount--;
-          item.resolve(value);
-          ConnectionQueue.dequeue();
-        })
-        .catch(err => {
-          ConnectionQueue.activelyConnectingCount--;
-          item.reject(err);
-          ConnectionQueue.dequeue();
-        })
-    } catch (err) {
+      await item.promiseGenerator(item.configObject);
       ConnectionQueue.activelyConnectingCount--;
-      item.reject(err);
+      ConnectionQueue.dequeue();
+    } catch (error) {
+      ConnectionQueue.activelyConnectingCount--;
       ConnectionQueue.dequeue();
     }
     return true;
@@ -402,10 +390,9 @@ class Pool {
   // odbc.connect runs on an AsyncWorker, so this is truly non-blocking
   async increasePoolSize(count) {
     this.connectionsBeingCreatedCount += count;
-    const promises = [];
     for (let i = 0; i < count; i++)
     {
-      promises.push(ConnectionQueue.enqueue(this, this.generateConnectPromise, this.connectionConfig));
+      ConnectionQueue.enqueue(this, this.generateConnectPromise, this.connectionConfig);
     }
   }
 }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -39,22 +39,21 @@ class ConnectionQueue
   static dequeue = async function()
   {
     if (this.activelyConnectingCount >= this.maxActivelyConnecting) {
-      return false;
+      return;
     }
     const item = this.queuedConnections.shift();
     if (!item) {
-      return false;
+      return;
     }
+    ConnectionQueue.activelyConnectingCount++;
     try {
-      ConnectionQueue.activelyConnectingCount++;
       await item.promiseGenerator(item.configObject);
-      ConnectionQueue.activelyConnectingCount--;
-      ConnectionQueue.dequeue();
     } catch (error) {
-      ConnectionQueue.activelyConnectingCount--;
-      ConnectionQueue.dequeue();
+      // We don't actually do anything with errors here
     }
-    return true;
+    ConnectionQueue.activelyConnectingCount--;
+    ConnectionQueue.dequeue();
+    return;
   }
 }
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -16,57 +16,130 @@ const MAX_SIZE_DEFAULT = Number.MAX_SAFE_INTEGER;
 const SHRINK_DEFAULT = true;
 const CONNECTION_TIMEOUT_DEFAULT = 0;
 const LOGIN_TIMEOUT_DEFAULT = 0;
-const CONNECTING_QUEUE_MAX = 1;
+const MAX_ACTIVELY_CONNECTING = 1;
+
+// A queue for tracking the connections 
+class ConnectionQueue
+{
+  static queuedConnections = [];
+  static activelyConnectingCount = 0;
+  static maxActivelyConnecting = MAX_ACTIVELY_CONNECTING;
+
+  static enqueue = async function(pool, promiseGenerator, configObject)
+  {
+    return new Promise((resolve, reject) => {
+      ConnectionQueue.queuedConnections.push({
+          pool,
+          promiseGenerator,
+          configObject,
+          resolve,
+          reject,
+      });
+      ConnectionQueue.dequeue();
+    });
+  }
+
+  static dequeue = function()
+  {
+    if (this.activelyConnectingCount >= this.maxActivelyConnecting) {
+      return false;
+    }
+    const item = this.queuedConnections.shift();
+    if (!item) {
+      return false;
+    }
+    try {
+      ConnectionQueue.activelyConnectingCount++;
+      item.promiseGenerator(item.configObject)
+        .then((value) => {
+          ConnectionQueue.activelyConnectingCount--;
+          item.resolve(value);
+          ConnectionQueue.dequeue();
+        })
+        .catch(err => {
+          ConnectionQueue.activelyConnectingCount--;
+          item.reject(err);
+          ConnectionQueue.dequeue();
+        })
+    } catch (err) {
+      ConnectionQueue.activelyConnectingCount--;
+      item.reject(err);
+      ConnectionQueue.dequeue();
+    }
+    return true;
+  }
+}
 
 class Pool {
 
   constructor(connectionString) {
 
+    this.connectionConfig = {};
+    this.waitingConnectionWork = [];
+    this.isOpen = false;
+    this.freeConnections = [];
+    this.connectionsBeingCreatedCount = 0;
+    this.poolSize = 0;
+
+    // Keeps track of when connections have sucessfully connected
     this.connectionEmitter = new EventEmitter();
+
+    // Fires when a connection has been made
     this.connectionEmitter.on('connected', (connection) => {
-      if (this.connectionQueue.length > 0)
+
+      // A connection has finished connecting, but there is some waiting call
+      // to connect() that is waiting for a connection. shift() that work from
+      // the front of the waitingConnectionWork queue, then either call the
+      // callback function provided by the user, or resolve the Promise that was
+      // returned to the user.
+      if (this.waitingConnectionWork.length > 0)
       {
-        let connectionWork = this.connectionQueue.pop();
+        let connectionWork = this.waitingConnectionWork.shift();
+
+        // If the user passed a callback function, then call the function with
+        // no error in the first parameter and the connection in the second
+        // parameter
         if (typeof connectionWork == 'function')
         {
-          // callback function
           return connectionWork(null, connection);
+        // If the user didn't pass a callback function, we returned a promise to
+        // them. Resolve that promise with the connection that was just created.
         } else {
           // Promise (stored resolve function)
           return connectionWork.resolveFunction(connection);
         }
+
+      // A connection finished connecting, and there was no work waiting for
+      // that connection to be made. Simply add it to the array of
+      // freeConnections, and the next time work comes in it can simply be
+      // retrieved from there.
       } else {
         this.freeConnections.push(connection);
       }
     });
 
-    this.isOpen = false;
-    this.freeConnections = [];
-    this.connectingCount = 0;
-    this.poolSize = 0;
-    this.connectionQueue = [];
-    this.connectingQueue = [];
-    this.connectingQueueCount = 0;
-
-    // connectionString is a...
+    // connectionString is a string, so use defaults for all of the
+    // configuration options.
     if (typeof connectionString === 'string') {
-      this.connectionString = connectionString;
+      this.connectionConfig.connectionString = connectionString;
 
       this.reuseConnections = REUSE_CONNECTIONS_DEFAULT;
       this.initialSize = INITIAL_SIZE_DEFAULT;
       this.incrementSize = INCREMENT_SIZE_DEFAULT;
       this.maxSize = MAX_SIZE_DEFAULT;
       this.shrink = SHRINK_DEFAULT;
-      this.connectionTimeout = CONNECTION_TIMEOUT_DEFAULT;
-      this.loginTimeout = LOGIN_TIMEOUT_DEFAULT;
-      this.connectingQueueMax = CONNECTING_QUEUE_MAX;
-
-    } else if (typeof connectionString === 'object') {
+      this.connectionConfig.connectionTimeout = CONNECTION_TIMEOUT_DEFAULT;
+      this.connectionConfig.loginTimeout = LOGIN_TIMEOUT_DEFAULT;
+    }
+    // connectionString is an object, so ensure that connectionString is a
+    // property on that object and then copy over any configuration options.
+    else if (typeof connectionString === 'object')
+    {
       const configObject = connectionString;
       if (!Object.prototype.hasOwnProperty.call(configObject, 'connectionString')) {
         throw new TypeError('Pool configuration object must contain "connectionString" key');
       }
-      this.connectionString = configObject.connectionString;
+      this.connectionConfig.connectionString = configObject.connectionString;
 
       // reuseConnections
       this.reuseConnections = configObject.reuseConnections !== undefined ? configObject.reuseConnections : REUSE_CONNECTIONS_DEFAULT;
@@ -84,65 +157,26 @@ class Pool {
       this.shrink = configObject.shrink !== undefined ? configObject.shrink : SHRINK_DEFAULT;
 
       // connectionTimeout
-      this.connectionTimeout = configObject.connectionTimeout !== undefined ? configObject.connectionTimeout : CONNECTION_TIMEOUT_DEFAULT;
+      this.connectionConfig.connectionTimeout = configObject.connectionTimeout !== undefined ? configObject.connectionTimeout : CONNECTION_TIMEOUT_DEFAULT;
 
       // loginTimeout
-      this.loginTimeout = configObject.loginTimeout !== undefined ? configObject.loginTimeout : LOGIN_TIMEOUT_DEFAULT;
+      this.connectionConfig.loginTimeout = configObject.loginTimeout !== undefined ? configObject.loginTimeout : LOGIN_TIMEOUT_DEFAULT;
 
       // connectingQueueMax
-      this.connectingQueueMax = configObject.connectingQueueMax !== undefined ? configObject.connectingQueueMax : CONNECTING_QUEUE_MAX;
-
-    } else {
+      // unlike other configuration values, this one is set statically on the
+      // ConnectionQueue object and not on the Pool intance
+      if (configObject.maxActivelyConnecting !== undefined)
+      {
+        ConnectionQueue.maxActivelyConnecting = configObject.maxActivelyConnecting
+      }
+    }
+    // connectionString was neither a string nor and object, so throw an error.
+    else
+    {
       throw TypeError('Pool constructor must passed a connection string or a configuration object');
     }
   }
 
-  enqueue = function(promise, configObject)
-  {
-    return new Promise((resolve, reject) => {
-      this.connectingQueue.push({
-          pool: this,
-          promise,
-          resolve,
-          reject,
-      });
-      this.dequeue(configObject);
-    });
-  }
-
-  dequeue = function(configObject)
-  {
-    if (this.connectingQueueCount >= this.connectingQueueMax) {
-      return false;
-    }
-    const item = this.connectingQueue.shift();
-    if (!item) {
-      return false;
-    }
-    try {
-      this.connectingQueueCount++;
-      item.promise(configObject)
-        .then((value) => {
-          this.connectingQueueCount--;
-          item.resolve(value);
-          this.dequeue(configObject);
-        })
-        .catch(err => {
-          this.connectingQueueCount--;
-          item.reject(err);
-          this.dequeue(configObject);
-        })
-    } catch (err) {
-      this.connectingQueueCount--;
-      item.reject(err);
-      this.dequeue(configObject);
-    }
-    return true;
-  }
-
-
-  // TODO: Documentation
-  // TODO: Does this need to be async?
   // returns a open connection, ready to use.
   // should overwrite the 'close' function of the connection, and rename it is 'nativeClose', so
   // that that close can still be called.
@@ -154,15 +188,19 @@ class Pool {
 
       // If the number of connections waiting is more (shouldn't happen) or
       // equal to the number of connections connecting, and the number of
-      // connections in the pool, in the process of connecting and that will be
+      // connections in the pool, in the process of connecting, and that will be
       // added is less than the maximum number of allowable connections, then
       // we will need to create MORE connections.
-      if (this.connectingCount <= this.connectionQueue.length &&
-          this.poolSize + this.connectingCount + this.incrementSize <= this.maxSize)
+      if (this.connectionsBeingCreatedCount <= this.waitingConnectionWork.length &&
+          this.poolSize + this.connectionsBeingCreatedCount + this.incrementSize <= this.maxSize)
       {
         this.increasePoolSize(this.incrementSize);
       }
 
+      // If no callback was provided when connect was called, we need to create
+      // a promise to return back. We also need to save off the resolve function
+      // of that promises callback, so that we can call it to resolve the
+      // function we returned
       if (typeof callback == 'undefined') {
         let resolveConnectionPromise;
 
@@ -173,13 +211,25 @@ class Pool {
           promise: promise,
           resolveFunction: resolveConnectionPromise
         }
-        this.connectionQueue.unshift(promiseObj);
+        // push the promise onto the waitingConnectionWork queue, then return
+        // it to the user
+        this.waitingConnectionWork.push(promiseObj);
         return promise;
-      } else {
-        this.connectionQueue.unshift(callback)
+      }
+      // If a callback was provided, we can just add that to the
+      // waitingConnectionWork queue, then return undefined to the user. Their
+      // callback will execute when a connection is ready
+      else
+      {
+        this.waitingConnectionWork.push(callback)
         return undefined;
       }
-    } else {
+    }
+    // Else, there was a free connection available for the user, so either
+    // return an immediately resolved promise, or call their callback
+    // immediately.
+    else
+    {
       connection = this.freeConnections.pop();
 
       // promise...
@@ -306,7 +356,7 @@ class Pool {
           return;
         }
 
-        this.pool.connectingCount--;
+        this.pool.connectionsBeingCreatedCount--;
         this.pool.poolSize++;
         let connection = new Connection(nativeConnection);
         connection.nativeClose = connection.close;
@@ -351,18 +401,12 @@ class Pool {
 
   // odbc.connect runs on an AsyncWorker, so this is truly non-blocking
   async increasePoolSize(count) {
-    this.connectingCount += count;
-    const connectionConfig = {
-      connectionString: this.connectionString,
-      connectionTimeout: this.connectionTimeout,
-      loginTimeout: this.loginTimeout,
-    };
+    this.connectionsBeingCreatedCount += count;
     const promises = [];
     for (let i = 0; i < count; i++)
     {
-      promises.push(this.enqueue(this.generateConnectPromise, connectionConfig));
+      promises.push(ConnectionQueue.enqueue(this, this.generateConnectPromise, this.connectionConfig));
     }
-    return await Promise.race(promises);
   }
 }
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -16,6 +16,7 @@ const MAX_SIZE_DEFAULT = Number.MAX_SAFE_INTEGER;
 const SHRINK_DEFAULT = true;
 const CONNECTION_TIMEOUT_DEFAULT = 0;
 const LOGIN_TIMEOUT_DEFAULT = 0;
+const CONNECTING_QUEUE_MAX = 1;
 
 class Pool {
 
@@ -44,6 +45,8 @@ class Pool {
     this.connectingCount = 0;
     this.poolSize = 0;
     this.connectionQueue = [];
+    this.connectingQueue = [];
+    this.connectingQueueCount = 0;
 
     // connectionString is a...
     if (typeof connectionString === 'string') {
@@ -56,6 +59,7 @@ class Pool {
       this.shrink = SHRINK_DEFAULT;
       this.connectionTimeout = CONNECTION_TIMEOUT_DEFAULT;
       this.loginTimeout = LOGIN_TIMEOUT_DEFAULT;
+      this.connectingQueueMax = CONNECTING_QUEUE_MAX;
 
     } else if (typeof connectionString === 'object') {
       const configObject = connectionString;
@@ -84,9 +88,56 @@ class Pool {
 
       // loginTimeout
       this.loginTimeout = configObject.loginTimeout !== undefined ? configObject.loginTimeout : LOGIN_TIMEOUT_DEFAULT;
+
+      // connectingQueueMax
+      this.connectingQueueMax = configObject.connectingQueueMax !== undefined ? configObject.connectingQueueMax : CONNECTING_QUEUE_MAX;
+
     } else {
       throw TypeError('Pool constructor must passed a connection string or a configuration object');
     }
+  }
+
+  enqueue = function(promise, configObject)
+  {
+    return new Promise((resolve, reject) => {
+      this.connectingQueue.push({
+          pool: this,
+          promise,
+          resolve,
+          reject,
+      });
+      this.dequeue(configObject);
+    });
+  }
+
+  dequeue = function(configObject)
+  {
+    if (this.connectingQueueCount >= this.connectingQueueMax) {
+      return false;
+    }
+    const item = this.connectingQueue.shift();
+    if (!item) {
+      return false;
+    }
+    try {
+      this.connectingQueueCount++;
+      item.promise(configObject)
+        .then((value) => {
+          this.connectingQueueCount--;
+          item.resolve(value);
+          this.dequeue(configObject);
+        })
+        .catch(err => {
+          this.connectingQueueCount--;
+          item.reject(err);
+          this.dequeue(configObject);
+        })
+    } catch (err) {
+      this.connectingQueueCount--;
+      item.reject(err);
+      this.dequeue(configObject);
+    }
+    return true;
   }
 
 
@@ -247,6 +298,57 @@ class Pool {
     return undefined;
   }
 
+  generateConnectPromise = function(connectionConfig) {
+    return new Promise((resolve, reject) => {
+      odbc.connect(connectionConfig, (error, nativeConnection) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        this.pool.connectingCount--;
+        this.pool.poolSize++;
+        let connection = new Connection(nativeConnection);
+        connection.nativeClose = connection.close;
+
+        if (this.pool.reuseConnections) {
+          connection.close = async (closeCallback = undefined) => {
+            this.pool.connectionEmitter.emit('connected', connection);
+
+            if (typeof closeCallback === 'undefined') {
+              return new Promise((resolve, reject) => {
+                resolve();
+              })
+            }
+
+            return closeCallback(null);
+          };
+        } else {
+          connection.close = async (closeCallback = undefined) => {
+            this.pool.increasePoolSize(1);
+            if (typeof closeCallback === 'undefined') {
+              return new Promise((resolve, reject) => {
+                connection.nativeClose((error, result) => {
+                  this.pool.poolSize--;
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(result);
+                  }
+                });
+              });
+            }
+      
+            connection.nativeClose(closeCallback);
+          }
+        }
+
+        this.pool.connectionEmitter.emit('connected', connection);
+        resolve();
+      });
+    });
+  }
+
   // odbc.connect runs on an AsyncWorker, so this is truly non-blocking
   async increasePoolSize(count) {
     this.connectingCount += count;
@@ -255,71 +357,12 @@ class Pool {
       connectionTimeout: this.connectionTimeout,
       loginTimeout: this.loginTimeout,
     };
-    return new Promise(async (resolve, reject) => {
-      const connectArray = [];
-      for (let i = 0; i < count; i += 1) {
-        let promise = new Promise((resolve, reject) => {
-          odbc.connect(connectionConfig, (error, nativeConnection) => {
-            this.connectingCount--;
-            if (error) {
-              reject(error);
-              return;
-            }
-
-            this.poolSize++;
-            let connection = new Connection(nativeConnection);
-            connection.nativeClose = connection.close;
-
-            if (this.reuseConnections) {
-              connection.close = async (closeCallback = undefined) => {
-                this.connectionEmitter.emit('connected', connection);
-
-                if (typeof closeCallback === 'undefined') {
-                  return new Promise((resolve, reject) => {
-                    resolve();
-                  })
-                }
-
-                return closeCallback(null);
-              };
-            } else {
-              connection.close = async (closeCallback = undefined) => {
-                this.increasePoolSize(1);
-                if (typeof closeCallback === 'undefined') {
-                  return new Promise((resolve, reject) => {
-                    connection.nativeClose((error, result) => {
-                      this.poolSize--;
-                      if (error) {
-                        reject(error);
-                      } else {
-                        resolve(result);
-                      }
-                    });
-                  });
-                }
-          
-                connection.nativeClose(closeCallback);
-              }
-            }
-
-            this.connectionEmitter.emit('connected', connection);
-            resolve();
-          });
-        });
-        connectArray.push(promise);
-      }
-      if (connectArray.length > 0)
-      {
-        try {
-          await Promise.race(connectArray);
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      } else {
-        resolve();
-      }
-    });
+    const promises = [];
+    for (let i = 0; i < count; i++)
+    {
+      promises.push(this.enqueue(this.generateConnectPromise, connectionConfig));
+    }
+    return await Promise.race(promises);
   }
 }
 

--- a/test/pool/close.js
+++ b/test/pool/close.js
@@ -15,7 +15,7 @@ describe('close()...', () => {
             assert.deepEqual(pool.freeConnections.length, 0);
             done();
           });
-        }, 5000);
+        }, 10000);
       });
     });
   }); // ...with callbacks...

--- a/test/pool/constructor.js
+++ b/test/pool/constructor.js
@@ -3,6 +3,8 @@ const assert         = require('assert');
 const odbc           = require('../../');
 const { Connection } = require('../../lib/Connection');
 
+const delay = t => new Promise(resolve => setTimeout(resolve, t));
+
 describe('odbc.pool...', () => {
   describe('...with callbacks...', () => {
     it('...should return the default number of open connections when no config passed.', (done) => {
@@ -46,10 +48,9 @@ describe('odbc.pool...', () => {
     it('...should return the default number of open connections when no config passed.', async () => {
       const pool = await odbc.pool(`${process.env.CONNECTION_STRING}`);
       assert.notDeepEqual(pool, null);
-      setTimeout(() => {
-        assert.deepEqual(pool.freeConnections.length, 10);
-        pool.close();
-      }, 8000);
+      await delay(8000);
+      assert.deepEqual(pool.freeConnections.length, 10);
+      pool.close();
     });
     it('...should open as many connections as passed with `initialSize` key...', async () => {
       const poolConfig = {
@@ -58,15 +59,15 @@ describe('odbc.pool...', () => {
       };
       const pool = await odbc.pool(poolConfig);
       assert.notDeepEqual(pool, null);
-      setTimeout(() => {
-        assert.deepEqual(pool.freeConnections.length, 5);
-        pool.close();
-      }, 5000);
+      await delay(5000);
+      assert.deepEqual(pool.freeConnections.length, 5);
+      pool.close();
     });
     it('...should have at least one free connection when .connect is called', async () => {
       const pool = await odbc.pool(`${process.env.CONNECTION_STRING}`);
       const connection = await pool.connect();
       assert.deepEqual(connection instanceof Connection, true);
+      pool.close();
     });
   }); // ...with promises...
 });


### PR DESCRIPTION
I have tried several times to get the "create lots of connections" part of connection pooling working as I want it to; namely, allow queries to run while all of the connections are spinning up (the first query running immediately after the first connection returns). Currently, when a pool is initialized with 10 connections, those 10 connections are queued up internally in the Node.js process, and any additional async worker will get queued up behind them. This means that the first query run after a pool is initialized won't actually be started for a long time (10+ seconds in the default case). I thought that using `Promise.race` would fix the issue, but in reality it didn't have any effect since the Promises began running as soon as they were declared.

I believe this PR finally gets it right. What is does is have an internal queue that can gate the number of connection Promises that are active at any one time. This will allow _some_ of the other threads to be available for doing other work, like running queries. I believe that Node.js has something like 4 threads available by default.

This queue doesn't hold Promises (which would be active if they were being held), but instead a function that generates those Promises. When there is an available thread for making a connection, it calls the function to generate the Promise that will create a connection. This connection is then added to the pool and emits the `connected` event, which will allow any queries that have been queued up to be executed.

I've also added a new keyword, `connectingQueueMax`, which allows users to specify how many threads should be dedicated to spinning up connections on the Pool. The default is 1.

I have tested this out, and it actually runs exactly as I've been hoping the pool to work since I made it: If initializing a pool of 10 connections, and allocating only 1 thread for making those connections, it will create the first connection, begin to create the second connection, begin making the query, and then return the query as soon as it has returned. This has reduced the "time to first query return" from something like 13 seconds down to less than 2 seconds (could be faster on other systems)