### PR TITLE
Add query options to Pool.query

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ In order to get a connection, you must use the `.connect` function exported from
     * `connectionString` **REQUIRED**: The connection string to connect to the database
     * `connectionTimeout`: The number of seconds to wait for a request on the connection to complete before returning to the application
     * `loginTimeout`: The number of seconds to wait for a login request to complete before returning to the application
-* **{OPTIONAL} callback**: The function called when `.connect` has finished connecting. If no callback function is given, `.connect` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.connect` has finished connecting. If no callback function is given, `.connect` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * connection: The Connection object if a successful connection was made
 
@@ -259,7 +259,7 @@ Run a query on the database. Can be passed an SQL string with parameter markers 
     * `fetchSize`: Used with a cursor, sets the number of rows that are returned on a call to `fetch` on the Cursor.
     * `timeout`: The amount of time (in seconds) that the query will attempt to execute before returning to the application.
     * `initialBufferSize`: Sets the initial buffer size (in bytes) for storing data from SQL_LONG* data fields. Useful for avoiding resizes if buffer size is known before the call.
-* **{OPTIONAL} callback**: The function called when `.query` has finished execution. If no callback function is given, `.query` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.query` has finished execution. If no callback function is given, `.query` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The result object from execution
 
@@ -283,8 +283,8 @@ Calls a database procedure, returning the results in a [result array](#result-ar
 * **catalog**: The name of the catalog where the procedure exists, or null to use the default catalog
 * **schema**: The name of the schema where the procedure exists, or null to use a default schema
 * **name**: The name of the procedure in the database
-* **{OPTIONAL} parameters**: An array of parameters to pass to the procedure. For input and input/output parameters, the JavaScript value passed in is expected to be of a type translatable to the SQL type the procedure expects. For output parameters, any JavaScript value can be passed in, and will be overwritten by the function. The number of parameters passed in must match the number of parameters expected by the procedure.
-* **{OPTIONAL} callback**: The function called when `.callProcedure` has finished execution. If no callback function is given, `.callProcedure` will return a native JavaScript `Promise`. Callback signature is:
+* **parameters?**: An array of parameters to pass to the procedure. For input and input/output parameters, the JavaScript value passed in is expected to be of a type translatable to the SQL type the procedure expects. For output parameters, any JavaScript value can be passed in, and will be overwritten by the function. The number of parameters passed in must match the number of parameters expected by the procedure.
+* **callback?**: The function called when `.callProcedure` has finished execution. If no callback function is given, `.callProcedure` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The result object from execution
 
@@ -327,7 +327,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Returns a [Statement](#Statement) object from the connection.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.createStatement` has finished execution. If no callback function is given, `.createStatement` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.createStatement` has finished execution. If no callback function is given, `.createStatement` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * statement: The newly created Statement object
 
@@ -373,7 +373,7 @@ Returns information about the table specified in the parameters by calling the O
 * **schema**: The name of the schema, or null if not specified
 * **table**: The name of the table, or null if not specified
 * **type**: The type of table that you want information about, or null if not specified
-* **{OPTIONAL} callback**: The function called when `.tables` has finished execution. If no callback function is given, `.tables` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.tables` has finished execution. If no callback function is given, `.tables` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The result object from execution
 
@@ -420,7 +420,7 @@ Returns information about the columns specified in the parameters by calling the
 * **schema**: The name of the schema, or null if not specified
 * **table**: The name of the table, or null if not specified
 * **column**: The name of the column that you want information about, or null if not specified
-* **{OPTIONAL} callback**: The function called when `.columns` has finished execution. If no callback function is given, `.columns` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.columns` has finished execution. If no callback function is given, `.columns` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The result object from execution
 
@@ -468,7 +468,7 @@ Sets the transaction isolation level for the connection, which determines what d
     * `odbc.SQL_TXN_READ_COMMITTED`
     * `odbc.SQL_TXN_REPEATABLE_READ`
     * `odbc.SQL_TXN_SERIALIZABLE`
-* **{OPTIONAL} callback**: The function called when `.setIsolationLevel` has finished execution. If no callback function is given, `.setIsolationLevel` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.setIsolationLevel` has finished execution. If no callback function is given, `.setIsolationLevel` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -508,7 +508,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Begins a transaction on the connection. The transaction can be committed by calling `.commit` or rolled back by calling `.rollback`. **If a connection is closed with an open transaction, it will be rolled back.** Connection isolation level will affect the data that other transactions can view mid transaction.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.beginTransaction` has finished execution. If no callback function is given, `.beginTransaction` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.beginTransaction` has finished execution. If no callback function is given, `.beginTransaction` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -548,7 +548,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Commits an open transaction. If called on a connection that doesn't have an open transaction, will no-op.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.commit` has finished execution. If no callback function is given, `.commit` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.commit` has finished execution. If no callback function is given, `.commit` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -596,7 +596,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Rolls back an open transaction. If called on a connection that doesn't have an open transaction, will no-op.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.rollback` has finished execution. If no callback function is given, `.rollback` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.rollback` has finished execution. If no callback function is given, `.rollback` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -643,7 +643,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Closes and open connection. Any transactions on the connection that have not been ended will be rolledback.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.close` has finished clsoing the connection. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.close` has finished clsoing the connection. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -698,7 +698,7 @@ Note that `odbc.pool` will return from callback or Promise as soon as it has cre
     * `incrementSize`: How many additional Connections to create when all of the Pool's connections are taken
     * `maxSize`: The maximum number of open Connections the Pool will create
     * `shrink`: Whether or not the number of Connections should shrink to `initialSize` as they free up
-* **{OPTIONAL} callback**: The function called when `.connect` has finished connecting. If no callback function is given, `.connect` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.connect` has finished connecting. If no callback function is given, `.connect` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * connection: The Connection object if a successful connection was made
 
@@ -732,7 +732,7 @@ const pool = odbc.pool('DSN=MyDSN', (error, pool) => {
 Returns a [Connection](#connection) object for you to use from the Pool. Doesn't actually open a connection, because they are already open in the pool when `.init` is called.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.connect` has finished execution. If no callback function is given, `.connect` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.connect` has finished execution. If no callback function is given, `.connect` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * connection: The [Connection](#connection) retrieved from the Pool.
 
@@ -774,8 +774,13 @@ Utility function to execute a query on any open connection in the pool. Will get
 
 #### Parameters:
 * **sql**: An SQL string that will be executed. Can optionally be given parameter markers (`?`) and also given an array of values to bind to the parameters.
-* **{OPTIONAL} parameters**: An array of values to bind to the parameter markers, if there are any. The number of values in this array must match the number of parameter markers in the sql statement.
-* **{OPTIONAL} callback**: The function called when `.query` has finished execution. If no callback function is given, `.query` will return a native JavaScript `Promise`. Callback signature is:
+* **parameters?**: An array of values to bind to the parameter markers, if there are any. The number of values in this array must match the number of parameter markers in the sql statement.
+* **options?**: An object containing query options that affect query behavior. Valid properties include:
+    * `cursor`: A boolean value indicating whether or not to return a cursor instead of results immediately. Can also be a string naming the cursor, which will assume that a cursor will be returned.
+    * `fetchSize`: Used with a cursor, sets the number of rows that are returned on a call to `fetch` on the Cursor.
+    * `timeout`: The amount of time (in seconds) that the query will attempt to execute before returning to the application.
+    * `initialBufferSize`: Sets the initial buffer size (in bytes) for storing data from SQL_LONG* data fields. Useful for avoiding resizes if buffer size is known before the call.
+* **callback?**: The function called when `.query` has finished execution. If no callback function is given, `.query` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The [result array](#result-array) returned from the executed statement
 
@@ -816,7 +821,7 @@ odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
 Closes the entire pool of currently unused connections. Will not close connections that are checked-out, but will discard the connections when they are closed with Connection's `.close` function. After calling close, must create a new Pool sprin up new Connections.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.close` has finished execution. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.close` has finished execution. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -868,7 +873,7 @@ Prepares an SQL statement, with or without parameters (?) to bind to.
 
 #### Parameters:
 * **sql**: An SQL string that is prepared and can be executed with the .`execute` function.
-* **{OPTIONAL} callback**: The function called when `.prepare` has finished execution. If no callback function is given, `.prepare` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.prepare` has finished execution. If no callback function is given, `.prepare` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -913,7 +918,7 @@ Binds an array of values to the parameters on the prepared SQL statement. Cannot
 
 #### Parameters:
 * **sql**: An array of values to bind to the sql statement previously prepared. All parameters will be input parameters. The number of values passed in the array must match the number of parameters to bind to in the prepared statement.
-* **{OPTIONAL} callback**: The function called when `.bind` has finished execution. If no callback function is given, `.bind` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.bind` has finished execution. If no callback function is given, `.bind` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -963,7 +968,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Executes the prepared and optionally bound SQL statement.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.execute` has finished execution. If no callback function is given, `.execute` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.execute` has finished execution. If no callback function is given, `.execute` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The [result array](#result-array) returned from the executed statement
 
@@ -1019,7 +1024,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Closes the Statement, freeing the statement handle. Running functions on the statement after closing will result in an error.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.close` has finished execution. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.close` has finished execution. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
 
 #### Examples:
@@ -1087,7 +1092,7 @@ Cursors allow you to fetch piecemeal instead of retrieving all rows at once. The
 Asynchronously returns the next chunk of rows from the result set and returns them as a Result object.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.fetch` has finished retrieving the result rows. If no callback function is given, `.fetch` will return a native JavaScript `Promise` that resolve the result rows. Callback signature is:
+* **callback?**: The function called when `.fetch` has finished retrieving the result rows. If no callback function is given, `.fetch` will return a native JavaScript `Promise` that resolve the result rows. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * results: The [result array](#result-array) returned from the executed statement with at most `fetchSize`-number of rows.
 
@@ -1193,7 +1198,7 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 Closes the statement that the cursor was generated from, and by extension the cursor itself. Needs to be called when the cursor is no longer needed.
 
 #### Parameters:
-* **{OPTIONAL} callback**: The function called when `.close` has finished execution. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
+* **callback?**: The function called when `.close` has finished execution. If no callback function is given, `.close` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured while closing the statement, or `null` if no error
 
 #### Examples:

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -272,7 +272,13 @@ class Pool {
       if (typeof options === 'function')
       {
         callback = options;
-        options = null;
+        if (typeof parameters === 'object' && !Array.isArray(parameters))
+        {
+          options = parameters;
+          parameters = null;
+        } else {
+          options = null;
+        }
       } else if (
         typeof options === 'undefined' &&
         typeof parameters === 'function')
@@ -302,12 +308,12 @@ class Pool {
       });
     }
 
+    // ...or callback
     this.connect((error, connection) => {
       if (error) {
         throw error;
       }
 
-      // ...or callback
       return connection.query(sql, parameters, options, (error, result) => {
         // after running, close the connection whether error or not
         process.nextTick(() => {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -262,18 +262,25 @@ class Pool {
     }
   };
 
-  async query(sql, params, cb) {
+  async query(sql, params, opts, cb) {
     // determine the parameters passed
     let callback = cb;
     let parameters = params;
+    let options = opts;
 
     if (typeof callback === 'undefined') {
-      if (typeof parameters === 'function') {
+      if (typeof options === 'function')
+      {
+        callback = options;
+        options = null;
+      } else if (
+        typeof options === 'undefined' &&
+        typeof parameters === 'function')
+      {
         callback = parameters;
+        options = null;
         parameters = null;
-      } else if (typeof parameters === 'undefined') {
-        parameters = null;
-      } // else parameters = params, check type in this.ODBCconnection.query
+      }
     }
 
     if (typeof callback !== 'function') {
@@ -283,7 +290,7 @@ class Pool {
             reject(error);
           }
 
-          connection.query(sql, parameters, (error, result) => {
+          connection.query(sql, parameters, options, (error, result) => {
             if (error) {
               reject(error);
             } else {
@@ -301,7 +308,7 @@ class Pool {
       }
 
       // ...or callback
-      return connection.query(sql, parameters, (error, result) => {
+      return connection.query(sql, parameters, options, (error, result) => {
         // after running, close the connection whether error or not
         process.nextTick(() => {
           callback(error, result);

--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -68,13 +68,22 @@ declare namespace odbc {
     shrink?: boolean;
   }
 
+  interface QueryOptions {
+    cursor?: boolean|string;
+    fetchSize?: number;
+    timeout?: number;
+    initialBufferSize?: number; 
+  }
+
   class Connection {
 
     ////////////////////////////////////////////////////////////////////////////
     //   Callbacks   ///////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
     query<T>(sql: string, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
-    query<T>(sql: string, parameters: Array<number|string>, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, parameters: Array<number|string>, options: QueryOptions, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, options: QueryOptions, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, parameters: Array<number|string>, options: QueryOptions, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
 
     callProcedure(catalog: string, schema: string, name: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
     callProcedure(catalog: string, schema: string, name: string, parameters: Array<number|string>, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
@@ -98,8 +107,10 @@ declare namespace odbc {
     ////////////////////////////////////////////////////////////////////////////
     //   Promises   ////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
-
-    query<T>(sql: string, parameters?: Array<number|string>): Promise<Result<T>>;
+    query<T>(sql: string): Promise<Result<T>>;
+    query<T>(sql: string, parameters: Array<number|string>): Promise<Result<T>>;
+    query<T>(sql: string, options: QueryOptions): Promise<Result<T>>;
+    query<T>(sql: string, parameters: Array<number|string>, options: QueryOptions): Promise<Result<T>>;
 
     callProcedure(catalog: string, schema: string, name: string, parameters?: Array<number|string>): Promise<Result<unknown>>;
 
@@ -127,8 +138,10 @@ declare namespace odbc {
     ////////////////////////////////////////////////////////////////////////////
     connect(callback: (error: NodeOdbcError, connection: Connection) => undefined): undefined;
 
-    query(sql: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
-    query(sql: string, parameters: Array<number|string>, callback: (error: NodeOdbcError, result: Array<any>) => undefined): undefined;
+    query<T>(sql: string, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, parameters: Array<number|string>, options: QueryOptions, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, options: QueryOptions, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
+    query<T>(sql: string, parameters: Array<number|string>, options: QueryOptions, callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
 
     close(callback: (error: NodeOdbcError) => undefined): undefined;
 
@@ -138,7 +151,10 @@ declare namespace odbc {
     ////////////////////////////////////////////////////////////////////////////
     connect(): Promise<Connection>;
 
-    query(sql: string, parameters?: Array<number|string>): Promise<Result<unknown>>;
+    query<T>(sql: string): Promise<Result<T>>;
+    query<T>(sql: string, parameters: Array<number|string>): Promise<Result<T>>;
+    query<T>(sql: string, options: QueryOptions): Promise<Result<T>>;
+    query<T>(sql: string, parameters: Array<number|string>, options: QueryOptions): Promise<Result<T>>;
 
     close(): Promise<void>;
   }

--- a/test/pool/query.js
+++ b/test/pool/query.js
@@ -1,8 +1,9 @@
 /* eslint-env node, mocha */
-const assert = require('assert');
-const odbc   = require('../../');
+const assert     = require('assert');
+const odbc       = require('../../');
+const { Cursor } = require('../../lib/Cursor');
 
-describe('.query...', () => {
+describe.only('.query...', () => {
   describe('...with callbacks...', () => {
     it('...should be able to insert and retrieve data from the database.', (done) => {
       odbc.pool(`${process.env.CONNECTION_STRING}`, (error, pool) => {
@@ -22,4 +23,307 @@ describe('.query...', () => {
       });
     });
   });
+  describe('...with promises...', () => {
+    it('...should correctly identify function signature with .query({string}).', async () => {
+      const pool = await odbc.pool({
+        connectionString: `${process.env.CONNECTION_STRING}`,
+        initialSize: 1
+      });
+      const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(1, 'committed', 10)`);
+      assert.notDeepEqual(result1, null);
+      assert.deepEqual(result1.length, 0);
+      assert.deepEqual(result1.count, 1);
+      const result2 = await pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`);
+      assert.notDeepEqual(result2, null);
+      assert.deepEqual(result2.length, 1);
+      assert.deepEqual(result2[0], { ID: 1, NAME: 'committed', AGE: 10 });
+      await pool.close();
+    });
+    it('...should correctly identify function signature with .query({string}, {array})', async () => {
+      const pool = await odbc.pool({
+        connectionString: `${process.env.CONNECTION_STRING}`,
+        initialSize: 1
+      });
+      const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+      assert.notDeepEqual(result1, null);
+      assert.deepEqual(result1.length, 0);
+      assert.deepEqual(result1.count, 1);
+      const result2 = await pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`);
+      assert.notDeepEqual(result2, null);
+      assert.deepEqual(result2.length, 1);
+      assert.deepEqual(result2[0], { ID: 1, NAME: 'committed', AGE: 10 });
+      await pool.close();
+    });
+    it('...should correctly identify function signature with .query({string}, {array}, {object})', async () => {
+      const pool = await odbc.pool({
+        connectionString: `${process.env.CONNECTION_STRING}`,
+        initialSize: 1
+      });
+      const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+      assert.notDeepEqual(result1, null);
+      assert.deepEqual(result1.length, 0);
+      assert.deepEqual(result1.count, 1);
+      const cursor = await pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} WHERE ID = ?`, [1], {cursor: true});
+      assert.notDeepEqual(cursor, null);
+      assert.ok(cursor instanceof Cursor);
+      await cursor.close();
+      await pool.close();
+    });
+    it('...should correctly identify function signature with .query({string}, {object})', async () => {
+      const pool = await odbc.pool({
+        connectionString: `${process.env.CONNECTION_STRING}`,
+        initialSize: 1
+      });
+      const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+      assert.notDeepEqual(result1, null);
+      assert.deepEqual(result1.length, 0);
+      assert.deepEqual(result1.count, 1);
+      const cursor = await pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, {cursor: true});
+      assert.notDeepEqual(cursor, null);
+      assert.ok(cursor instanceof Cursor);
+      await cursor.close();
+      await pool.close();
+    });
+    describe('...testing query options...', () => {
+      describe('...[cursor]...', () => {
+        it('...should throw an error if cursor is not a boolean or string', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: 1 }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .cursor must be a STRING or BOOLEAN value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .cursor must be a STRING or BOOLEAN value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: null }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .cursor must be a STRING or BOOLEAN value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: () => {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .cursor must be a STRING or BOOLEAN value.'
+            }
+          );
+          await pool.close();
+        });
+      });
+      describe('...[fetchSize]...', () => {
+        it('...should throw an error if fetchSize is not a number', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: true }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .fetchSize must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .fetchSize must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: '1' }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .fetchSize must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: () => {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .fetchSize must be a NUMBER value.'
+            }
+          );
+          await pool.close();
+        });
+        it('...should throw an error if fetchSize is less-than or equal to 0', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: 0 }),
+            {
+              name: 'RangeError',
+              message: 'Connection.query options: .fetchSize must be greater than 0.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: -1 }),
+            {
+              name: 'RangeError',
+              message: 'Connection.query options: .fetchSize must be greater than 0.'
+            }
+          );
+          await pool.close();
+        });
+      });
+      describe('...[timeout]...', () => {
+        it('...should throw an error if timeout is not a number', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: true }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .timeout must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .timeout must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: '1' }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .timeout must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: () => {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .timeout must be a NUMBER value.'
+            }
+          );
+          await pool.close();
+        });
+        it('...should throw an error if timeout is less-than or equal to 0', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: 0 }),
+            {
+              name: 'RangeError',
+              message: 'Connection.query options: .timeout must be greater than 0.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: -1 }),
+            {
+              name: 'RangeError',
+              message: 'Connection.query options: .timeout must be greater than 0.'
+            }
+          );
+          await pool.close();
+        });
+      });
+      describe('...[initialBufferSize]...', () => {
+        it('...should throw an error if initialBufferSize is not a number', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: true }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .initialBufferSize must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .initialBufferSize must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: '1' }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .initialBufferSize must be a NUMBER value.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: () => {} }),
+            {
+              name: 'TypeError',
+              message: 'Connection.query options: .initialBufferSize must be a NUMBER value.'
+            }
+          );
+          await pool.close();
+        });
+        it('...should throw an error if initialBufferSize is less-than or equal to 0', async () => {
+          const pool = await odbc.pool({
+            connectionString: `${process.env.CONNECTION_STRING}`,
+            initialSize: 1
+          });
+          const result1 = await pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10]);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, {initialBufferSize: 0}),
+            {
+              name: 'RangeError',
+              message: 'Connection.query options: .initialBufferSize must be greater than 0.'
+            }
+          );
+          await assert.rejects(
+            pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, {initialBufferSize: -1}),
+            {
+              name: 'RangeError',
+              message: 'Connection.query options: .initialBufferSize must be greater than 0.'
+            }
+          );
+          await pool.close();
+        });
+      });
+    });
+  }); // ...with promises...
 });

--- a/test/pool/query.js
+++ b/test/pool/query.js
@@ -5,19 +5,294 @@ const { Cursor } = require('../../lib/Cursor');
 
 describe.only('.query...', () => {
   describe('...with callbacks...', () => {
-    it('...should be able to insert and retrieve data from the database.', (done) => {
+    it('...should correctly identify function signature with .query({string}, {function}).', (done) => {
       odbc.pool(`${process.env.CONNECTION_STRING}`, (error, pool) => {
-        assert.deepStrictEqual(error, null);
-        assert.notDeepEqual(pool, null);
+        assert.deepEqual(error, null);
         pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(1, 'committed', 10)`, (error1, result1) => {
-          assert.deepStrictEqual(error1, null);
+          assert.deepEqual(error1, null);
           assert.notDeepEqual(result1, null);
-          assert.deepStrictEqual(result1.count, 1);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
           pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, (error2, result2) => {
-            assert.deepStrictEqual(error2, null);
+            assert.deepEqual(error2, null);
             assert.notDeepEqual(result2, null);
-            assert.deepStrictEqual(result2.length, 1);
-            done();
+            assert.deepEqual(result2.length, 1);
+            assert.deepEqual(result2[0], { ID: 1, NAME: 'committed', AGE: 10 });
+            pool.close((error3) => {
+              assert.deepEqual(error3, null);
+              done();
+            });
+          });
+        });
+      });
+    });
+    it('...should correctly identify function signature with .query({string}, {array}, {function})', (done) => {
+      odbc.pool(`${process.env.CONNECTION_STRING}`, (error, pool) => {
+        pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error1, result1) => {
+          assert.deepEqual(error1, null);
+          assert.notDeepEqual(result1, null);
+          assert.deepEqual(result1.length, 0);
+          assert.deepEqual(result1.count, 1);
+          pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, (error2, result2) => {
+            assert.deepEqual(error2, null);
+            assert.notDeepEqual(result2, null);
+            assert.deepEqual(result2.length, 1);
+            assert.deepEqual(result2[0], { ID: 1, NAME: 'committed', AGE: 10 });
+            pool.close((error3) => {
+              assert.deepEqual(error3, null);
+              done();
+            });
+          });
+        });
+      });
+    });
+    it('...should correctly identify function signature with .query({string}, {array}, {object}, {function})', (done) => {
+      odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+        assert.deepEqual(error1, null);
+        assert.notDeepEqual(pool, undefined);
+        pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result) => {
+          assert.deepEqual(error2, null);
+          assert.notDeepEqual(result, undefined);
+          assert.deepEqual(result.length, 0);
+          assert.deepEqual(result.count, 1);
+          pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} WHERE ID = ?`, [1], { cursor: true }, (error3, cursor) => {
+            assert.deepEqual(error3, null);
+            assert.notDeepEqual(cursor, undefined);
+            assert.ok(cursor instanceof Cursor);
+            cursor.close((error4) => {
+              assert.deepEqual(error4, null);
+              pool.close((error5) => {
+                assert.deepEqual(error5, null);
+                done();
+              });
+            })
+          });
+        });
+      });
+    });
+    it('...should correctly identify function signature with .query({string}, {object}, {function})', (done) => {
+      odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+        assert.deepEqual(error1, null);
+        assert.notDeepEqual(pool, undefined);
+        pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result) => {
+          assert.deepEqual(error2, null);
+          assert.notDeepEqual(result, undefined);
+          assert.deepEqual(result.length, 0);
+          assert.deepEqual(result.count, 1);
+          pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, {cursor: true}, (error3, cursor) => {
+            assert.deepEqual(error3, null);
+            assert.notDeepEqual(cursor, undefined);
+            assert.ok(cursor instanceof Cursor);
+            cursor.close((error4) => {
+              assert.deepEqual(error4, null);
+              pool.close((error5) => {
+                assert.deepEqual(error5, null);
+                done();
+              });
+            })
+          });
+        });
+      });
+    });
+    describe('...testing query options...', () => {
+      describe('...[cursor]...', () => {
+        it('...should return an error if cursor is not a boolean or string', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: 1 }, (error3, cursor3) => {
+                assert.deepEqual(error3, TypeError('Connection.query options: .cursor must be a STRING or BOOLEAN value.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: {} }, (error4, cursor4) => {
+                  assert.deepEqual(error4, TypeError('Connection.query options: .cursor must be a STRING or BOOLEAN value.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: null }, (error5, cursor5) => {
+                    assert.deepEqual(error5, TypeError('Connection.query options: .cursor must be a STRING or BOOLEAN value.'));
+                    assert.deepEqual(cursor5, undefined);
+                    pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { cursor: () => {} }, (error6, cursor6) => {
+                      assert.deepEqual(error6, TypeError('Connection.query options: .cursor must be a STRING or BOOLEAN value.'));
+                      assert.deepEqual(cursor6, undefined);
+                      pool.close((error7) => {
+                        assert.deepEqual(error7, null);
+                        done();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+      describe('...[fetchSize]...', () => {
+        it('...should return an error if fetchSize is not a number', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: true }, (error3, cursor3) => {
+                assert.deepEqual(error3, TypeError('Connection.query options: .fetchSize must be a NUMBER value.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: {} }, (error4, cursor4) => {
+                  assert.deepEqual(error4, TypeError('Connection.query options: .fetchSize must be a NUMBER value.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: null }, (error5, cursor5) => {
+                    assert.deepEqual(error5, TypeError('Connection.query options: .fetchSize must be a NUMBER value.'));
+                    assert.deepEqual(cursor5, undefined);
+                    pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: () => {} }, (error6, cursor6) => {
+                      assert.deepEqual(error6, TypeError('Connection.query options: .fetchSize must be a NUMBER value.'));
+                      assert.deepEqual(cursor6, undefined);
+                      pool.close((error7) => {
+                        assert.deepEqual(error7, null);
+                        done();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+        it('...should return an error if fetchSize is less-than or equal to 0', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: 0 }, (error3, cursor3) => {
+                assert.deepEqual(error3, RangeError('Connection.query options: .fetchSize must be greater than 0.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { fetchSize: -1 }, (error4, cursor4) => {
+                  assert.deepEqual(error4, RangeError('Connection.query options: .fetchSize must be greater than 0.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.close((error5) => {
+                    assert.deepEqual(error5, null);
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+      describe('...[timeout]...', () => {
+        it('...should return an error if timeout is not a number', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: true }, (error3, cursor3) => {
+                assert.deepEqual(error3, TypeError('Connection.query options: .timeout must be a NUMBER value.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: {} }, (error4, cursor4) => {
+                  assert.deepEqual(error4, TypeError('Connection.query options: .timeout must be a NUMBER value.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: null }, (error5, cursor5) => {
+                    assert.deepEqual(error5, TypeError('Connection.query options: .timeout must be a NUMBER value.'));
+                    assert.deepEqual(cursor5, undefined);
+                    pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: () => {} }, (error6, cursor6) => {
+                      assert.deepEqual(error6, TypeError('Connection.query options: .timeout must be a NUMBER value.'));
+                      assert.deepEqual(cursor6, undefined);
+                      pool.close((error7) => {
+                        assert.deepEqual(error7, null);
+                        done();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+        it('...should return an error if timeout is less-than or equal to 0', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: 0 }, (error3, cursor3) => {
+                assert.deepEqual(error3, RangeError('Connection.query options: .timeout must be greater than 0.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { timeout: -1 }, (error4, cursor4) => {
+                  assert.deepEqual(error4, RangeError('Connection.query options: .timeout must be greater than 0.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.close((error5) => {
+                    assert.deepEqual(error5, null);
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+      describe('...[initialBufferSize]...', () => {
+        it('...should return an error if initialBufferSize is not a number', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: true }, (error3, cursor3) => {
+                assert.deepEqual(error3, TypeError('Connection.query options: .initialBufferSize must be a NUMBER value.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: {} }, (error4, cursor4) => {
+                  assert.deepEqual(error4, TypeError('Connection.query options: .initialBufferSize must be a NUMBER value.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: null }, (error5, cursor5) => {
+                    assert.deepEqual(error5, TypeError('Connection.query options: .initialBufferSize must be a NUMBER value.'));
+                    assert.deepEqual(cursor5, undefined);
+                    pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: () => {} }, (error6, cursor6) => {
+                      assert.deepEqual(error6, TypeError('Connection.query options: .initialBufferSize must be a NUMBER value.'));
+                      assert.deepEqual(cursor6, undefined);
+                      pool.close((error7) => {
+                        assert.deepEqual(error7, null);
+                        done();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+        it('...should return an error if initialBufferSize is less-than or equal to 0', (done) => {
+          odbc.pool(`${process.env.CONNECTION_STRING}`, (error1, pool) => {
+            assert.deepEqual(error1, null);
+            assert.notDeepEqual(pool, null);
+            pool.query(`INSERT INTO ${process.env.DB_SCHEMA}.${process.env.DB_TABLE} VALUES(?, ?, ?)`, [1, 'committed', 10], (error2, result2) => {
+              assert.deepEqual(error2, null);
+              assert.notDeepEqual(result2, null);
+              assert.deepEqual(result2.length, 0);
+              pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: 0 }, (error3, cursor3) => {
+                assert.deepEqual(error3, RangeError('Connection.query options: .initialBufferSize must be greater than 0.'));
+                assert.deepEqual(cursor3, undefined);
+                pool.query(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, { initialBufferSize: -1 }, (error4, cursor4) => {
+                  assert.deepEqual(error4, RangeError('Connection.query options: .initialBufferSize must be greater than 0.'));
+                  assert.deepEqual(cursor4, undefined);
+                  pool.close((error5) => {
+                    assert.deepEqual(error5, null);
+                    done();
+                  });
+                });
+              });
+            });
           });
         });
       });


### PR DESCRIPTION
I realized when going to close #154 that query options were never added to the `.query` function added to pools. This PR seeks to remedy that oversight.