### PR TITLE
Fixing a segfault caused by new binding code paths

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1323,6 +1323,13 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
 
       data->deleteColumns(); // delete data in columns for next result set
 
+      return_code =
+      set_fetch_size
+      (
+        data,
+        1
+      );
+
       return_code = 
       SQLProcedureColumns
       (


### PR DESCRIPTION
Ran tests before pushing a new version, and came across this segfault:

When calling a procedure, the first call thats made is `SQLProcedures`. After the data is stored from that call, `data->deleteColumns()` is called. Immediately after deleting columns, need to re-call the `set_fetch_size()`, which creates the `data->row_status_array`. This array is deleted in `deleteColumns()`, so it causes a segfault without this recreation.

225/225 tests passed after this fix