### PR TITLE
Create binding.gyp path for M1/ARM macOS systems

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,28 +27,25 @@
           ]
         }],
         [ 'OS == "mac"', {
-          'variables': {
-            'arch': '<!(uname -p)',
-          },
           'conditions': [
-             [ '"<(arch)"=="arm"', {
-               'include_dirs': [
-                  '/opt/homebrew/include'
-                ],
-                'libraries' : [
-                  '-L/opt/homebrew/lib',
-                  '-lodbc'
-                ],
-             }], ['"<(arch)"=="arm"', {
-               'include_dirs': [
-                  '/usr/local/include',
-                ],
-                'libraries' : [
-                  '-L/usr/local/lib',
-                  '-lodbc'
-                ],
-             }],
-          ]
+            [ 'target_arch=="arm64"', {
+              'include_dirs': [
+                '/opt/homebrew/include'
+              ],  
+              'libraries' : [
+                '-L/opt/homebrew/lib',
+                '-lodbc'
+              ],  
+            }], ['target_arch=="x64"', {
+              'include_dirs': [
+                '/usr/local/include',
+              ],  
+              'libraries' : [
+                '-L/usr/local/lib',
+                '-lodbc'
+              ],
+            }],
+          ],
           'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
         }],
         [ 'OS == "freebsd"', {


### PR DESCRIPTION
Create a path for giving the right include dirs and libraries for ARM-based mac systems. Fixes ##223. Thanks to @kadler for testing the file.