### PR TITLE
feat: Add generic result type to Statement#execute

### DIFF
--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -36,7 +36,7 @@ declare namespace odbc {
 
     bind(parameters: Array<number|string>, callback: (error: NodeOdbcError) => undefined): undefined;
 
-    execute(callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
+    execute<T>(callback: (error: NodeOdbcError, result: Result<T>) => undefined): undefined;
 
     close(callback: (error: NodeOdbcError) => undefined): undefined;
 
@@ -48,7 +48,7 @@ declare namespace odbc {
   
     bind(parameters: Array<number|string>): Promise<void>;
   
-    execute(): Promise<Result<unknown>>;
+    execute<T>(): Promise<Result<T>>;
   
     close(): Promise<void>;
   }


### PR DESCRIPTION
Signed-off-by: Christian Marker / Intility AS <christian.marker@intility.no>

Adding missing generic return type to Statement#execute function, just as in Connection#query.