### PR TITLE
Initialize overwriteParams in CallProcedureAsyncWorker

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1930,7 +1930,9 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
   public:
     CallProcedureAsyncWorker(ODBCConnection *odbcConnectionObject, Napi::Value napiParameterArray, StatementData *data, Napi::Function& callback) : ODBCAsyncWorker(callback),
       odbcConnectionObject(odbcConnectionObject),
-      data(data) {
+      data(data),
+      overwriteParams(NULL)
+      {
         if (napiParameterArray.IsArray()) {
           napiParameters = Napi::Persistent(napiParameterArray.As<Napi::Array>());
         } else {

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1265,7 +1265,7 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
     ODBCConnection *odbcConnectionObject;
     Napi::Reference<Napi::Array>    napiParameters;
     StatementData  *data;
-    unsigned char  *overwriteParams;
+    unsigned char  *overwriteParams {nullptr};
 
     void Execute() {
 
@@ -1930,8 +1930,7 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
   public:
     CallProcedureAsyncWorker(ODBCConnection *odbcConnectionObject, Napi::Value napiParameterArray, StatementData *data, Napi::Function& callback) : ODBCAsyncWorker(callback),
       odbcConnectionObject(odbcConnectionObject),
-      data(data),
-      overwriteParams(NULL)
+      data(data)
       {
         if (napiParameterArray.IsArray()) {
           napiParameters = Napi::Persistent(napiParameterArray.As<Napi::Array>());


### PR DESCRIPTION
If overwriteParams isn't initialized, a memory error can occur if the callProcedure exits early due to wrong procedure name or wrong number of parameters

`overwriteParams` is used to indicate whether a field is an `INPUT` parameter, or an `INPUT/OUT` or `OUTPUT` parameter. This is so we can preserve the Javascript value for INPUT parameters instead of trying to go JavaScript -> C type -> convert C-type based on parameter ODBC type -> C type -> JavaScript, when the value should remain constant. `overwriteParams` is only set after a successful call to `SQLProcedureColumns`, so it is currently erroring when trying to call `delete` in the structure for a pointer that was never set.

Signed-off-by: Mark Irish <mirish@ibm.com>