### PR TITLE
Add binding.gyp path for OS400

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -80,6 +80,10 @@
                 'cflags' : ['-std=c++0x', '-DNAPI_DISABLE_CPP_EXCEPTIONS', '-Wall', '-Wextra', '-Wno-unused-parameter', '-I/QOpenSys/usr/include', '-I/QOpenSys/pkgs/include']
              }]
           ]
+        }],
+        [ 'OS=="os400"', {
+          'ldflags': ['-Wl,-blibpath:/QOpenSys/pkgs/lib', '-lodbc'],
+          'cflags' : ['-std=c++0x', '-DNAPI_DISABLE_CPP_EXCEPTIONS', '-Wall', '-Wextra', '-Wno-unused-parameter', '-I/QOpenSys/usr/include', '-I/QOpenSys/pkgs/include']
         }]
       ]
     },


### PR DESCRIPTION
When building with Python 3.9 (eg. PYTHON=python3.9 npm i), gyp sets OS
to "os400" since Python now returns that from sys.platform. Copy the
existing IBM i config from the AIX branch and simplify since we know
it's IBM i in that branch.

Signed-off-by: Kevin Adler <kadler@us.ibm.com>