### PR TITLE
Build and upload binaries for all GitHub Actions runners

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,16 +27,70 @@ jobs:
     - name: Package Binary
       run: ./node_modules/.bin/node-pre-gyp package
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: binaries
+        name: windows-binaries
+        path: build/stage/*.tar.gz
+
+  build-macos:
+
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Upgrade NPM
+      run: npm install -g npm
+    - run: npm install -g node-gyp
+    - run: npm ci --production
+    - run: ./node_modules/.bin/node-pre-gyp rebuild --production
+    - name: Package Binary
+      run: ./node_modules/.bin/node-pre-gyp package
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: macos-binaries
+        path: build/stage/*.tar.gz
+
+  build-linux:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Upgrade NPM
+      run: npm install -g npm
+    - run: npm install -g node-gyp
+    - run: npm ci --production
+    - run: ./node_modules/.bin/node-pre-gyp rebuild --production
+    - name: Package Binary
+      run: ./node_modules/.bin/node-pre-gyp package
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-binaries
         path: build/stage/*.tar.gz
 
   create-release:
 
     runs-on: ubuntu-latest
 
-    needs: [build-windows]
+    needs: [build-windows, build-macos, build-linux]
 
     steps:
 
@@ -57,18 +111,135 @@ jobs:
         draft: true
         prerelease: false
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: binaries
 
-    # Upload the various binaries
+    # Download all of the various binaries that were created
+    - uses: actions/download-artifact@v3
 
+    # There is no 'upload-release-artifact' package that currently allows
+    # uploading to a draft release, other than the GitHub action that is no
+    # longer supported. However, that package allows only uploading one file
+    # at a time. Bit the bullet for now, contribute to one of the other projects
+    # later
+
+    # Windows binaries
     - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
+        asset_path: ./windows-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
         asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v3.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v4.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./windows-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v4.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v4.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v5.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./windows-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v5.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v5.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v6.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./windows-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v6.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-win32-x64-napi-v6.tar.gz
+        asset_content_type: application/gzip
+
+    # Macos binaries
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v3.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./macos-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v3.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v3.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v4.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./macos-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v4.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v4.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v5.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./macos-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v5.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v5.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v6.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./macos-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v6.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-darwin-x64-napi-v6.tar.gz
+        asset_content_type: application/gzip
+
+    # Linux binaries
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v3.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./linux-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v3.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v3.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v4.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./linux-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v4.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v4.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v5.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./linux-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v5.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v5.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v6.tar.gz
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./linux-binaries/odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v6.tar.gz
+        asset_name: odbc-v${{ steps.package-version.outputs.current-version }}-linux-x64-napi-v6.tar.gz
         asset_content_type: application/gzip


### PR DESCRIPTION
Previously, we only built a binary of one napi version (v3) on one operating system (Windows). Update the action so that it builds all of our built napi versions for Windows, MacOS, and Linux, and upload those prebuilt binaries to the draft release that is created

Signed-off-by: Mark Irish <mirish@ibm.com>