### PR TITLE
Fixup Statement.execute query options

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,11 +962,16 @@ odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
 
 ---
 
-### `.execute(callback?)`
+### `.execute(options?, callback?)`
 
 Executes the prepared and optionally bound SQL statement.
 
 #### Parameters:
+* **options?**: An object containing options that affect execution behavior. Valid properties include:
+    * `cursor`: A boolean value indicating whether or not to return a cursor instead of results immediately. Can also be a string naming the cursor, which will assume that a cursor will be returned. In order to close the `Statement`, you can call `.close()` on either the `Cursor` or the `Statement`.
+    * `fetchSize`: Used with a cursor, sets the number of rows that are returned on a call to `fetch` on the Cursor.
+    * `timeout`: The amount of time (in seconds) that the query will attempt to execute before returning to the application.
+    * `initialBufferSize`: Sets the initial buffer size (in bytes) for storing data from SQL_LONG* data fields. Useful for avoiding resizes if buffer size is known before the call.
 * **callback?**: The function called when `.execute` has finished execution. If no callback function is given, `.execute` will return a native JavaScript `Promise`. Callback signature is:
     * error: The error that occured in execution, or `null` if no error
     * result: The [result array](#result-array) returned from the executed statement

--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ Executes the prepared and optionally bound SQL statement.
 
 #### Parameters:
 * **options?**: An object containing options that affect execution behavior. Valid properties include:
-    * `cursor`: A boolean value indicating whether or not to return a cursor instead of results immediately. Can also be a string naming the cursor, which will assume that a cursor will be returned. In order to close the `Statement`, you can call `.close()` on either the `Cursor` or the `Statement`.
+    * `cursor`: A boolean value indicating whether or not to return a cursor instead of results immediately. Can also be a string naming the cursor, which will assume that a cursor will be returned. Closing the `Statement` will also close the `Cursor`, but closing the `Cursor` will keep the `Statement` valid.
     * `fetchSize`: Used with a cursor, sets the number of rows that are returned on a call to `fetch` on the Cursor.
     * `timeout`: The amount of time (in seconds) that the query will attempt to execute before returning to the application.
     * `initialBufferSize`: Sets the initial buffer size (in bytes) for storing data from SQL_LONG* data fields. Useful for avoiding resizes if buffer size is known before the call.

--- a/test/statement/execute.test.js
+++ b/test/statement/execute.test.js
@@ -251,6 +251,23 @@ describe('.execute([calback])...', () => {
         });
       });
     });
+    it.only('...should accept a timeout option without crashing', (done) => {
+      connection.createStatement((error1, statement) => {
+        assert.deepEqual(error1, null);
+        assert.notDeepEqual(statement, null);
+        statement.prepare(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`, (error2) => {
+          assert.deepEqual(error2, null);
+          statement.execute({timeout: 10}, (error3, result) => {
+            assert.deepEqual(error3, null);
+            assert.notDeepEqual(result, null);
+            statement.close((error4) => {
+              assert.deepEqual(error4, null);
+              done();
+            });
+          });
+        });
+      });
+    });
   }); // '...with callbacks...'
   describe('...with promises...', () => {
     it('...should execute if a valid SQL string has been prepared and valid values bound.', async () => {
@@ -364,6 +381,14 @@ describe('.execute([calback])...', () => {
       assert.deepEqual(statementResult[0].ID, 1);
       assert.deepEqual(statementResult[0].NAME, 'bound');
       assert.deepEqual(statementResult[0].AGE, 10);
+      await statement.close();
+    });
+    it.only('...should accept a timeout option without crashing', async () => {
+      const statement = await connection.createStatement();
+      assert.notDeepEqual(statement, null);
+      await statement.prepare(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`);
+      const result = await statement.execute({timeout: 10});
+      assert.notDeepEqual(result, null);
       await statement.close();
     });
   }); // '...with promises...'


### PR DESCRIPTION
Add execution timeout code path for Statement.execute
Add README.md entries for using query options with Statement.execute
Add tests to ensure setting query timeout at this point won't crash ODBC

Fixes #272 

Signed-off-by: Mark Irish <mirish@ibm.com>