### PR TITLE
Add primaryKeys() and foreignKeys() functions on Connection

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -296,6 +296,60 @@ class Connection {
   }
 
   // TODO: Documentation
+  primaryKeys(catalog, schema, table, callback = undefined) {
+    // promise...
+    if (callback === undefined) {
+      if (!this.odbcConnection)
+      {
+        throw new Error(Connection.CONNECTION_CLOSED_ERROR);
+      }
+      return new Promise((resolve, reject) => {
+        this.odbcConnection.primaryKeys(catalog, schema, table, (error, result) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(result);
+          }
+        });
+      });
+    }
+
+    // ...or callback
+    if (!this.odbcConnection) {
+      callback(new Error(Connection.CONNECTION_CLOSED_ERROR));
+    } else {
+      this.odbcConnection.primaryKeys(catalog, schema, table, callback);
+    }
+  }
+
+  // TODO: Documentation
+  foreignKeys(catalog, schema, table, fkCatalog, fkSchema, fkTable, callback = undefined) {
+    // promise...
+    if (callback === undefined) {
+      if (!this.odbcConnection)
+      {
+        throw new Error(Connection.CONNECTION_CLOSED_ERROR);
+      }
+      return new Promise((resolve, reject) => {
+        this.odbcConnection.foreignKeys(catalog, schema, table, fkCatalog, fkSchema, fkTable, (error, result) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(result);
+          }
+        });
+      });
+    }
+
+    // ...or callback
+    if (!this.odbcConnection) {
+      callback(new Error(Connection.CONNECTION_CLOSED_ERROR));
+    } else {
+      this.odbcConnection.foreignKeys(catalog, schema, table, fkCatalog, fkSchema, fkTable, callback);
+    }
+  }
+
+  // TODO: Documentation
   columns(catalog, schema, table, type, callback = undefined) {
     // promise...
     if (callback === undefined) {

--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -94,7 +94,11 @@ declare namespace odbc {
 
     createStatement(callback: (error: NodeOdbcError, statement: Statement) => undefined): undefined;
 
-    tables(catalog: string, schema: string, table: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
+    primaryKeys(catalog: string, schema: string, table: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
+
+    foreignKeys(pkCatalog: string, pkSchema: string, pkTable: string, fkCatalog: string, fkSchema: string, fkTable: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
+
+    tables(catalog: string, schema: string, table: string, type: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
 
     columns(catalog: string, schema: string, table: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined): undefined;
 
@@ -119,6 +123,10 @@ declare namespace odbc {
     callProcedure(catalog: string, schema: string, name: string, parameters?: Array<number|string>): Promise<Result<unknown>>;
 
     createStatement(): Promise<Statement>;
+
+    primaryKeys(catalog: string, schema: string, table: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined):  Promise<Result<unknown>>;
+
+    foreignKeys(pkCatalog: string, pkSchema: string, pkTable: string, fkCatalog: string, fkSchema: string, fkTable: string, callback: (error: NodeOdbcError, result: Result<unknown>) => undefined):  Promise<Result<unknown>>;
 
     tables(catalog: string, schema: string, table: string, type: string): Promise<Result<unknown>>;
 

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -212,6 +212,9 @@ typedef struct StatementData {
   SQLTCHAR *catalog   = NULL;
   SQLTCHAR *schema    = NULL;
   SQLTCHAR *table     = NULL;
+  SQLTCHAR *fkCatalog = NULL;
+  SQLTCHAR *fkSchema  = NULL;
+  SQLTCHAR *fkTable   = NULL;
   SQLTCHAR *type      = NULL;
   SQLTCHAR *column    = NULL;
   SQLTCHAR *procedure = NULL;
@@ -249,6 +252,9 @@ typedef struct StatementData {
     delete[] this->catalog; this->catalog = NULL;
     delete[] this->schema; this->schema = NULL;
     delete[] this->table; this->table = NULL;
+    delete[] this->fkCatalog; this->fkCatalog = NULL;
+    delete[] this->fkSchema; this->fkSchema = NULL;
+    delete[] this->fkTable; this->fkTable = NULL;
     delete[] this->type; this->type = NULL;
     delete[] this->column; this->column = NULL;
     delete[] this->procedure; this->procedure = NULL;

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -26,6 +26,7 @@
 #include <uv.h>
 #include <napi.h>
 #include <wchar.h>
+#include <new>
 
 #include <algorithm>
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -2230,26 +2230,24 @@ Napi::Value ODBCConnection::PrimaryKeys(const Napi::CallbackInfo& info) {
   }
 
   Napi::Function callback;
-  StatementData* data                      = new StatementData();
-                 data->henv                = this->hENV;
-                 data->hdbc                = this->hDBC;
-                 data->fetch_array         = this->connectionOptions.fetchArray;
-                 data->maxColumnNameLength = this->getInfoResults.max_column_name_length;
-                 data->get_data_supports   = this->getInfoResults.sql_get_data_supports;
+  StatementData* data = new (std::nothrow) StatementData();
   // Napi doesn't have LowMemoryNotification like NAN did. Throw standard error.
   if (!data) {
     Napi::TypeError::New(env, "Could not allocate enough memory to run query.").ThrowAsJavaScriptException();
-    delete data;
-    data = NULL;
     return env.Null();
   }
+  
+  data->henv                = this->hENV;
+  data->hdbc                = this->hDBC;
+  data->fetch_array         = this->connectionOptions.fetchArray;
+  data->maxColumnNameLength = this->getInfoResults.max_column_name_length;
+  data->get_data_supports   = this->getInfoResults.sql_get_data_supports;
 
   if (info[0].IsString()) {
     data->catalog = ODBC::NapiStringToSQLTCHAR(info[0].ToString());
   } else if (!info[0].IsNull()) {
     Napi::TypeError::New(env, "primaryKeys: first argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2258,7 +2256,6 @@ Napi::Value ODBCConnection::PrimaryKeys(const Napi::CallbackInfo& info) {
   } else if (!info[1].IsNull()) {
     Napi::TypeError::New(env, "primaryKeys: second argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2267,7 +2264,6 @@ Napi::Value ODBCConnection::PrimaryKeys(const Napi::CallbackInfo& info) {
   } else if (!info[2].IsNull()) {
     Napi::TypeError::New(env, "primaryKeys: third argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2275,7 +2271,6 @@ Napi::Value ODBCConnection::PrimaryKeys(const Napi::CallbackInfo& info) {
   else {
     Napi::TypeError::New(env, "primaryKeys: fourth argument must be a function").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2432,26 +2427,25 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   }
 
   Napi::Function callback;
-  StatementData* data                      = new StatementData();
-                 data->henv                = this->hENV;
-                 data->hdbc                = this->hDBC;
-                 data->fetch_array         = this->connectionOptions.fetchArray;
-                 data->maxColumnNameLength = this->getInfoResults.max_column_name_length;
-                 data->get_data_supports   = this->getInfoResults.sql_get_data_supports;
+  StatementData* data = new (std::nothrow) StatementData();
+
   // Napi doesn't have LowMemoryNotification like NAN did. Throw standard error.
   if (!data) {
     Napi::TypeError::New(env, "Could not allocate enough memory to run query.").ThrowAsJavaScriptException();
-    delete data;
-    data = NULL;
     return env.Null();
   }
+
+  data->henv                = this->hENV;
+  data->hdbc                = this->hDBC;
+  data->fetch_array         = this->connectionOptions.fetchArray;
+  data->maxColumnNameLength = this->getInfoResults.max_column_name_length;
+  data->get_data_supports   = this->getInfoResults.sql_get_data_supports;
 
   if (info[0].IsString()) {
     data->catalog = ODBC::NapiStringToSQLTCHAR(info[0].ToString());
   } else if (!info[0].IsNull()) {
     Napi::TypeError::New(env, "foriegnKeys: first argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2460,7 +2454,6 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   } else if (!info[1].IsNull()) {
     Napi::TypeError::New(env, "foriegnKeys: second argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2469,7 +2462,6 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   } else if (!info[2].IsNull()) {
     Napi::TypeError::New(env, "foriegnKeys: third argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2478,7 +2470,6 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   } else if (!info[3].IsNull()) {
     Napi::TypeError::New(env, "foriegnKeys: fourth argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2487,7 +2478,6 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   } else if (!info[4].IsNull()) {
     Napi::TypeError::New(env, "foriegnKeys: fifth argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2496,7 +2486,6 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   } else if (!info[5].IsNull()) {
     Napi::TypeError::New(env, "foriegnKeys: sixth argument must be a string or null").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 
@@ -2504,7 +2493,6 @@ Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
   else {
     Napi::TypeError::New(env, "foriegnKeys: seventh argument must be a function").ThrowAsJavaScriptException();
     delete data;
-    data = NULL;
     return env.Null();
   }
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -51,6 +51,8 @@ Napi::Object ODBCConnection::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("rollback", &ODBCConnection::Rollback),
     InstanceMethod("callProcedure", &ODBCConnection::CallProcedure),
     InstanceMethod("getUsername", &ODBCConnection::GetUsername),
+    InstanceMethod("primaryKeys", &ODBCConnection::PrimaryKeys),
+    InstanceMethod("foreignKeys", &ODBCConnection::ForeignKeys),
     InstanceMethod("tables", &ODBCConnection::Tables),
     InstanceMethod("columns", &ODBCConnection::Columns),
     InstanceMethod("setIsolationLevel", &ODBCConnection::SetIsolationLevel),
@@ -2089,6 +2091,427 @@ Napi::Value ODBCConnection::GetInfo(const Napi::Env env, const SQLUSMALLINT opti
   // TODO: Fix
   // Napi::Error(env, Napi::String::New(env, ODBC::GetSQLError(SQL_HANDLE_DBC, this->hDBC, (char *) "[node-odbc] Error in ODBCConnection::GetInfo"))).ThrowAsJavaScriptException();
   return env.Null();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  PrimaryKeys
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// PrimaryKeysAsyncWorker, used by the PrimaryKeys function below
+class PrimaryKeysAsyncWorker : public ODBCAsyncWorker
+{
+    private:
+
+    ODBCConnection *odbcConnectionObject;
+    StatementData  *data;
+
+    void Execute() {
+
+      SQLRETURN return_code;
+
+      uv_mutex_lock(&ODBC::g_odbcMutex);
+      return_code = SQLAllocHandle(
+        SQL_HANDLE_STMT,            // HandleType
+        odbcConnectionObject->hDBC, // InputHandle
+        &data->hstmt                // OutputHandlePtr
+      );
+      uv_mutex_unlock(&ODBC::g_odbcMutex);
+      if (!SQL_SUCCEEDED(return_code)) {
+        this->errors = GetODBCErrors(SQL_HANDLE_DBC, odbcConnectionObject->hDBC);
+        SetError("[odbc] Error allocating a statement handle to get primary key information\0");
+        return;
+      }
+
+      return_code =
+      set_fetch_size
+      (
+        data,
+        1
+      );
+
+      return_code =
+      SQLPrimaryKeys
+      (
+        data->hstmt,     // StatementHandle
+        data->catalog,   // CatalogName
+        SQL_NTS,         // NameLength1
+        data->schema,    // SchemaName
+        SQL_NTS,         // NameLength2
+        data->table,     // TableName
+        SQL_NTS          // NameLength3 
+      );
+      if (!SQL_SUCCEEDED(return_code)) {
+        this->errors = GetODBCErrors(SQL_HANDLE_STMT, data->hstmt);
+        SetError("[odbc] Error getting table information\0");
+        return;
+      }
+
+      return_code = prepare_for_fetch(data);
+      bool alloc_error = false;
+      return_code =
+      fetch_all_and_store
+      (
+        data,
+        false,
+        &alloc_error
+      );
+      if (alloc_error)
+      {
+        SetError("[odbc] Error allocating or reallocating memory when fetching data. No ODBC error information available.\0");
+        return;
+      }
+      if (!SQL_SUCCEEDED(return_code)) {
+        this->errors = GetODBCErrors(SQL_HANDLE_STMT, data->hstmt);
+        SetError("[odbc] Error retrieving table information results set\0");
+        return;
+      }
+    }
+
+    void OnOK() {
+
+      Napi::Env env = Env();
+      Napi::HandleScope scope(env);
+
+      std::vector<napi_value> callbackArguments;
+
+      callbackArguments.push_back(env.Null());
+
+      Napi::Array empty = Napi::Array::New(env);
+      Napi::Array rows = process_data_for_napi(env, data, empty);
+      callbackArguments.push_back(rows);
+
+      Callback().Call(callbackArguments);
+    }
+
+  public:
+
+    PrimaryKeysAsyncWorker(ODBCConnection *odbcConnectionObject, StatementData *data, Napi::Function& callback) : ODBCAsyncWorker(callback),
+      odbcConnectionObject(odbcConnectionObject),
+      data(data) {}
+
+    ~PrimaryKeysAsyncWorker() {
+      delete data;
+      data = NULL;
+    }
+};
+
+//
+//  ODBCConnection::PrimaryKeys
+//
+//    Description: Returns the columns names that make up the primary key for a
+//                 table.
+//
+//    Parameters:
+//      const Napi::CallbackInfo& info:
+//        The information passed from the JavaSript environment, including the
+//        function arguments for 'tables'.
+//
+//        info[0]: String: catalog
+//        info[1]: String: schema
+//        info[2]: String: table
+//        info[3]: Function: callback function:
+//            function(error, result)
+//              error: An error object if there was a database issue
+//              result: The ODBCResult
+//
+//    Return:
+//      Napi::Value:
+//        Undefined (results returned in callback)
+//
+Napi::Value ODBCConnection::PrimaryKeys(const Napi::CallbackInfo& info) {
+
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 4) {
+    Napi::TypeError::New(env, "primaryKeys() function takes 4 arguments.").ThrowAsJavaScriptException();
+  }
+
+  Napi::Function callback;
+  StatementData* data                      = new StatementData();
+                 data->henv                = this->hENV;
+                 data->hdbc                = this->hDBC;
+                 data->fetch_array         = this->connectionOptions.fetchArray;
+                 data->maxColumnNameLength = this->getInfoResults.max_column_name_length;
+                 data->get_data_supports   = this->getInfoResults.sql_get_data_supports;
+  // Napi doesn't have LowMemoryNotification like NAN did. Throw standard error.
+  if (!data) {
+    Napi::TypeError::New(env, "Could not allocate enough memory to run query.").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[0].IsString()) {
+    data->catalog = ODBC::NapiStringToSQLTCHAR(info[0].ToString());
+  } else if (!info[0].IsNull()) {
+    Napi::TypeError::New(env, "primaryKeys: first argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[1].IsString()) {
+    data->schema = ODBC::NapiStringToSQLTCHAR(info[1].ToString());
+  } else if (!info[1].IsNull()) {
+    Napi::TypeError::New(env, "primaryKeys: second argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[2].IsString()) {
+    data->table = ODBC::NapiStringToSQLTCHAR(info[2].ToString());
+  } else if (!info[2].IsNull()) {
+    Napi::TypeError::New(env, "primaryKeys: third argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[3].IsFunction()) { callback = info[3].As<Napi::Function>(); }
+  else {
+    Napi::TypeError::New(env, "primaryKeys: fourth argument must be a function").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  PrimaryKeysAsyncWorker *worker = new PrimaryKeysAsyncWorker(this, data, callback);
+  worker->Queue();
+
+  return env.Undefined();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  ForeignKeys
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// ForeignKeysAsyncWorker, used by the ForeignKeys function below
+class ForeignKeysAsyncWorker : public ODBCAsyncWorker
+{
+    private:
+
+    ODBCConnection *odbcConnectionObject;
+    StatementData  *data;
+
+    void Execute() {
+
+      SQLRETURN return_code;
+
+      uv_mutex_lock(&ODBC::g_odbcMutex);
+      return_code = SQLAllocHandle(
+        SQL_HANDLE_STMT,            // HandleType
+        odbcConnectionObject->hDBC, // InputHandle
+        &data->hstmt                // OutputHandlePtr
+      );
+      uv_mutex_unlock(&ODBC::g_odbcMutex);
+      if (!SQL_SUCCEEDED(return_code)) {
+        this->errors = GetODBCErrors(SQL_HANDLE_DBC, odbcConnectionObject->hDBC);
+        SetError("[odbc] Error allocating a statement handle to get foriegn key information\0");
+        return;
+      }
+
+      return_code =
+      set_fetch_size
+      (
+        data,
+        1
+      );
+
+      return_code =
+      SQLForeignKeys
+      (
+        data->hstmt,     // StatementHandle
+        data->catalog,   // PKCatalogName
+        SQL_NTS,         // NameLength1
+        data->schema,    // PKSchemaName
+        SQL_NTS,         // NameLength2
+        data->table,     // PKTableName
+        SQL_NTS,         // NameLength3 
+        data->fkCatalog, // FKCatalogName
+        SQL_NTS,         // NameLength4,  
+        data->fkSchema,   // FKSchemaName
+        SQL_NTS,         // NameLength5,  
+        data->fkTable,   // FKTableName,  
+        SQL_NTS          // NameLength6
+      );
+      if (!SQL_SUCCEEDED(return_code)) {
+        this->errors = GetODBCErrors(SQL_HANDLE_STMT, data->hstmt);
+        SetError("[odbc] Error getting table information\0");
+        return;
+      }
+
+      return_code = prepare_for_fetch(data);
+      bool alloc_error = false;
+      return_code =
+      fetch_all_and_store
+      (
+        data,
+        false,
+        &alloc_error
+      );
+      if (alloc_error)
+      {
+        SetError("[odbc] Error allocating or reallocating memory when fetching data. No ODBC error information available.\0");
+        return;
+      }
+      if (!SQL_SUCCEEDED(return_code)) {
+        this->errors = GetODBCErrors(SQL_HANDLE_STMT, data->hstmt);
+        SetError("[odbc] Error retrieving table information results set\0");
+        return;
+      }
+    }
+
+    void OnOK() {
+
+      Napi::Env env = Env();
+      Napi::HandleScope scope(env);
+
+      std::vector<napi_value> callbackArguments;
+
+      callbackArguments.push_back(env.Null());
+
+      Napi::Array empty = Napi::Array::New(env);
+      Napi::Array rows = process_data_for_napi(env, data, empty);
+      callbackArguments.push_back(rows);
+
+      Callback().Call(callbackArguments);
+    }
+
+  public:
+
+    ForeignKeysAsyncWorker(ODBCConnection *odbcConnectionObject, StatementData *data, Napi::Function& callback) : ODBCAsyncWorker(callback),
+      odbcConnectionObject(odbcConnectionObject),
+      data(data) {}
+
+    ~ForeignKeysAsyncWorker() {
+      delete data;
+      data = NULL;
+    }
+};
+
+//
+//  ODBCConnection::ForeignKeys
+//
+//    Description: Returns either a list of foreign keys in the specified able,
+//    or foriegn keys in other tables that refer to the primary key in the
+//    specified table.
+//
+//    Parameters:
+//      const Napi::CallbackInfo& info:
+//        The information passed from the JavaSript environment, including the
+//        function arguments for 'tables'.
+//
+//        info[0]: String: primaryKeyCatalog
+//        info[1]: String: primaryKeySchema
+//        info[2]: String: primaryKeyTable
+//        info[3]: String: foreignKeyCatalog
+//        info[4]: String: foreignKeySchema
+//        info[5]: String: foreignKeyTable
+//        info[6]: Function: callback function:
+//            function(error, result)
+//              error: An error object if there was a database issue
+//              result: The ODBCResult
+//
+//    Return:
+//      Napi::Value:
+//        Undefined (results returned in callback)
+//
+Napi::Value ODBCConnection::ForeignKeys(const Napi::CallbackInfo& info) {
+
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 7) {
+    Napi::TypeError::New(env, "foriegnKeys() function takes 7 arguments.").ThrowAsJavaScriptException();
+  }
+
+  Napi::Function callback;
+  StatementData* data                      = new StatementData();
+                 data->henv                = this->hENV;
+                 data->hdbc                = this->hDBC;
+                 data->fetch_array         = this->connectionOptions.fetchArray;
+                 data->maxColumnNameLength = this->getInfoResults.max_column_name_length;
+                 data->get_data_supports   = this->getInfoResults.sql_get_data_supports;
+  // Napi doesn't have LowMemoryNotification like NAN did. Throw standard error.
+  if (!data) {
+    Napi::TypeError::New(env, "Could not allocate enough memory to run query.").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[0].IsString()) {
+    data->catalog = ODBC::NapiStringToSQLTCHAR(info[0].ToString());
+  } else if (!info[0].IsNull()) {
+    Napi::TypeError::New(env, "foriegnKeys: first argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[1].IsString()) {
+    data->schema = ODBC::NapiStringToSQLTCHAR(info[1].ToString());
+  } else if (!info[1].IsNull()) {
+    Napi::TypeError::New(env, "foriegnKeys: second argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[2].IsString()) {
+    data->table = ODBC::NapiStringToSQLTCHAR(info[2].ToString());
+  } else if (!info[2].IsNull()) {
+    Napi::TypeError::New(env, "foriegnKeys: third argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[3].IsString()) {
+    data->fkCatalog = ODBC::NapiStringToSQLTCHAR(info[3].ToString());
+  } else if (!info[3].IsNull()) {
+    Napi::TypeError::New(env, "foriegnKeys: fourth argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[4].IsString()) {
+    data->fkSchema = ODBC::NapiStringToSQLTCHAR(info[4].ToString());
+  } else if (!info[4].IsNull()) {
+    Napi::TypeError::New(env, "foriegnKeys: fifth argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[5].IsString()) {
+    data->fkTable = ODBC::NapiStringToSQLTCHAR(info[5].ToString());
+  } else if (!info[5].IsNull()) {
+    Napi::TypeError::New(env, "foriegnKeys: sixth argument must be a string or null").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  if (info[6].IsFunction()) { callback = info[6].As<Napi::Function>(); }
+  else {
+    Napi::TypeError::New(env, "foriegnKeys: seventh argument must be a function").ThrowAsJavaScriptException();
+    delete data;
+    data = NULL;
+    return env.Null();
+  }
+
+  ForeignKeysAsyncWorker *worker = new ForeignKeysAsyncWorker(this, data, callback);
+  worker->Queue();
+
+  return env.Undefined();
 }
 
 /******************************************************************************

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -29,6 +29,8 @@ class ODBCConnection : public Napi::ObjectWrap<ODBCConnection> {
   friend class QueryAsyncWorker;
   friend class BeginTransactionAsyncWorker;
   friend class EndTransactionAsyncWorker;
+  friend class PrimaryKeysAsyncWorker;
+  friend class ForeignKeysAsyncWorker;
   friend class TablesAsyncWorker;
   friend class ColumnsAsyncWorker;
   friend class GetInfoAsyncWorker;
@@ -68,8 +70,11 @@ class ODBCConnection : public Napi::ObjectWrap<ODBCConnection> {
   Napi::Value Rollback(const Napi::CallbackInfo &rollback);
 
   Napi::Value GetUsername(const Napi::CallbackInfo &info);
+
   Napi::Value Columns(const Napi::CallbackInfo& info);
   Napi::Value Tables(const Napi::CallbackInfo& info);
+  Napi::Value PrimaryKeys(const Napi::CallbackInfo& info);
+  Napi::Value ForeignKeys(const Napi::CallbackInfo& info);
 
   Napi::Value GetConnAttr(const Napi::CallbackInfo& info);
   Napi::Value SetConnAttr(const Napi::CallbackInfo& info);

--- a/test/DBMS/ibmi/config.js
+++ b/test/DBMS/ibmi/config.js
@@ -134,6 +134,151 @@ module.exports = {
       nullable: true,
     },
   ],
+  sqlForeignKeysColumns: [
+    {
+      name: 'PKTABLE_CAT',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'PKTABLE_SCHEM',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'PKTABLE_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 256,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'PKCOLUMN_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 256,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'FKTABLE_CAT',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'FKTABLE_SCHEM',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'FKTABLE_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 256,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'FKCOLUMN_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 256,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'KEY_SEQ',
+      dataType: odbc.SQL_SMALLINT,
+      columnSize: 5,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'UPDATE_RULE',
+      dataType: odbc.SQL_SMALLINT,
+      columnSize: 5,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'DELETE_RULE',
+      dataType: odbc.SQL_SMALLINT,
+      columnSize: 5,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'FK_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'PK_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'DEFERRABILITY',
+      dataType: odbc.SQL_SMALLINT,
+      columnSize: 5,
+      decimalDigits: 0,
+      nullable: true
+    }
+  ],
+  sqlPrimaryKeysColumns: [
+    {
+      name: 'TABLE_CAT',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'TABLE_SCHEM',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    },
+    {
+      name: 'TABLE_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 256,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'COLUMN_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 256,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'KEY_SEQ',
+      dataType: odbc.SQL_SMALLINT,
+      columnSize: 5,
+      decimalDigits: 0,
+      nullable: false
+    },
+    {
+      name: 'PK_NAME',
+      dataType: odbc.SQL_VARCHAR,
+      columnSize: 128,
+      decimalDigits: 0,
+      nullable: true
+    }
+
+  ],
   sqlTablesColumns: [
     {
       columnSize: 18,

--- a/test/connection/_test.test.js
+++ b/test/connection/_test.test.js
@@ -9,6 +9,8 @@ describe('Connection', () => {
   require('./commit.test.js');
   require('./rollback.test.js');
   require('./columns.test.js');
+  require('./primaryKeys.test.js');
+  require('./foreignkeys.test.js');
   require('./tables.test.js');
   require('./callProcedure.test.js');
   require('./setIsolationLevel.test.js');

--- a/test/connection/foreignkeys.test.js
+++ b/test/connection/foreignkeys.test.js
@@ -1,0 +1,101 @@
+/* eslint-env node, mocha */
+const assert = require('assert');
+const odbc   = require('../../lib/odbc');
+
+describe('.foreignKeys(catalog, schema, table, fkCatalog, fkSchema, fkTable, callback)...', () => {
+  before(async () => {
+    let connection;
+    try {
+      connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const query1 = `CREATE OR REPLACE TABLE ${process.env.DB_SCHEMA}.PKTABLE (ID INTEGER, NAME VARCHAR(24), AGE INTEGER, PRIMARY KEY(ID))`;
+      const query2 = `CREATE OR REPLACE TABLE ${process.env.DB_SCHEMA}.FKTABLE (PKID INTEGER, NAME VARCHAR(24), FOREIGN KEY(PKID) REFERENCES PKTABLE(ID))`;
+      await connection.query(query1);
+      await connection.query(query2);
+    } catch (error) {
+      if (error.odbcErrors[0].code !== -601) {
+        throw (error);
+      }
+    } finally {
+      await connection.close();
+    }
+  });
+
+  after(async () => {
+    let connection;
+    try {
+      connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const query1 = `DROP TABLE ${process.env.DB_SCHEMA}.PKTABLE`;
+      const query2 = `DROP TABLE ${process.env.DB_SCHEMA}.FKTABLE`;
+      await connection.query(query1);
+      await connection.query(query2);
+    } catch (error) {
+      if (error.odbcErrors[0].code !== -601) {
+        throw (error);
+      }
+    } finally {
+      await connection.close();
+    }
+  });
+
+  describe('...with callbacks...', () => {
+    it('...should return information about a foreign key.', (done) => {
+      odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
+        assert.deepEqual(error, null);
+        connection.foreignKeys(null, `${process.env.DB_SCHEMA}`, 'PKTABLE', null, `${process.env.DB_SCHEMA}`, 'FKTABLE', (error1, results) => {
+          assert.strictEqual(error1, null);
+          assert.strictEqual(results.length, 1);
+          assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlForeignKeysColumns);
+
+          const result = results[0];
+          // not testing for TABLE_CAT, dependent on the system
+          assert.strictEqual(result.PKTABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+          assert.strictEqual(result.PKTABLE_NAME, 'PKTABLE');
+          assert.strictEqual(result.PKCOLUMN_NAME, 'ID');
+          assert.strictEqual(result.FKTABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+          assert.strictEqual(result.FKTABLE_NAME, 'FKTABLE');
+          assert.strictEqual(result.FKCOLUMN_NAME, 'PKID');
+          done();
+        });
+      });
+    });
+    it('...should return empty with bad parameters.', (done) => {
+      odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
+        assert.deepEqual(error, null);
+        connection.foreignKeys(null, 'bad schema name', 'bad table name', null, 'badschema2', 'badtable2', (error1, results) => {
+          assert.strictEqual(error1, null);
+          assert.strictEqual(results.length, 0);
+          assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlForeignKeysColumns);
+
+          done();
+        });
+      });
+    });
+  }); // ...with callbacks...
+  describe('...with promises...', () => {
+    it('...should return information about a primary key.', async () => {
+      const connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      
+      const results = await connection.foreignKeys(null, `${process.env.DB_SCHEMA}`, 'PKTABLE', null, `${process.env.DB_SCHEMA}`, 'FKTABLE');
+      assert.strictEqual(results.length, 1);
+      assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlForeignKeysColumns);
+
+      const result = results[0];
+      // not testing for TABLE_CAT, dependent on the system
+      assert.strictEqual(result.PKTABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+      assert.strictEqual(result.PKTABLE_NAME, 'PKTABLE');
+      assert.strictEqual(result.PKCOLUMN_NAME, 'ID');
+      assert.strictEqual(result.FKTABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+      assert.strictEqual(result.FKTABLE_NAME, 'FKTABLE');
+      assert.strictEqual(result.FKCOLUMN_NAME, 'PKID');
+      await connection.close();
+    });
+    it('...should return empty with bad parameters.', async () => {
+      const connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const results = await connection.foreignKeys(null, 'bad schema name', 'bad table name', null, "badschema2", "badtable2");
+
+      assert.strictEqual(results.length, 0);
+      assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlForeignKeysColumns);
+      await connection.close();
+    });
+  }); // ...with promises...
+});

--- a/test/connection/primaryKeys.test.js
+++ b/test/connection/primaryKeys.test.js
@@ -1,0 +1,138 @@
+/* eslint-env node, mocha */
+const assert = require('assert');
+const odbc   = require('../../lib/odbc');
+
+describe('.primaryKeys(catalog, schema, table, callback)...', () => {
+  before(async () => {
+    let connection;
+    try {
+      connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const query1 = `CREATE OR REPLACE TABLE ${process.env.DB_SCHEMA}.PKTEST (ID INTEGER, NAME VARCHAR(24), AGE INTEGER, PRIMARY KEY(ID))`;
+      const query2 = `CREATE OR REPLACE TABLE ${process.env.DB_SCHEMA}.MULTIPKTEST (ID INTEGER, NUM INTEGER, NAME VARCHAR(24), AGE INTEGER, PRIMARY KEY(ID, NUM))`;
+      await connection.query(query1);
+      await connection.query(query2);
+    } catch (error) {
+      if (error.odbcErrors[0].code !== -601) {
+        throw (error);
+      }
+    } finally {
+      await connection.close();
+    }
+  });
+
+  after(async () => {
+    let connection;
+    try {
+      connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const query1 = `DROP TABLE ${process.env.DB_SCHEMA}.PKTEST`;
+      const query2 = `DROP TABLE ${process.env.DB_SCHEMA}.MULTIPKTEST`;
+      await connection.query(query1);
+      await connection.query(query2);
+    } catch (error) {
+      if (error.odbcErrors[0].code !== -601) {
+        throw (error);
+      }
+    } finally {
+      await connection.close();
+    }
+  });
+
+  describe('...with callbacks...', () => {
+    it('...should return information about a primary key.', (done) => {
+      odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
+        assert.deepEqual(error, null);
+        connection.primaryKeys(null, `${process.env.DB_SCHEMA}`, 'PKTEST', (error1, results) => {
+          assert.strictEqual(error1, null);
+          assert.strictEqual(results.length, 1);
+          assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlPrimaryKeysColumns);
+
+          const result = results[0];
+          // not testing for TABLE_CAT, dependent on the system
+          assert.strictEqual(result.TABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+          assert.strictEqual(result.TABLE_NAME, 'PKTEST');
+          assert.strictEqual(result.COLUMN_NAME, 'ID');
+          done();
+        });
+      });
+    });
+    it('...should return information about a primary key with multiple columns.', (done) => {
+      odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
+        assert.deepEqual(error, null);
+        connection.primaryKeys(null, `${process.env.DB_SCHEMA}`, 'MULTIPKTEST', (error1, results) => {
+          assert.strictEqual(error1, null);
+          assert.strictEqual(results.length, 2);
+          assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlPrimaryKeysColumns);
+
+          let result = results[0];
+          // not testing for TABLE_CAT, dependent on the system
+          assert.strictEqual(result.TABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+          assert.strictEqual(result.TABLE_NAME, 'MULTIPKTEST');
+          assert.strictEqual(result.COLUMN_NAME, 'ID');
+
+          result = results[1];
+          // not testing for TABLE_CAT, dependent on the system
+          assert.strictEqual(result.TABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+          assert.strictEqual(result.TABLE_NAME, 'MULTIPKTEST');
+          assert.strictEqual(result.COLUMN_NAME, 'NUM');
+          done();
+        });
+      });
+    });
+    it('...should return empty with bad parameters.', (done) => {
+      odbc.connect(`${process.env.CONNECTION_STRING}`, (error, connection) => {
+        assert.deepEqual(error, null);
+        connection.primaryKeys(null, 'bad schema name', 'bad table name', (error1, results) => {
+          assert.strictEqual(error1, null);
+          assert.strictEqual(results.length, 0);
+          assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlPrimaryKeysColumns);
+
+          done();
+        });
+      });
+    });
+  }); // ...with callbacks...
+  describe('...with promises...', () => {
+    it('...should return information about a primary key.', async () => {
+      const connection =  await odbc.connect(`${process.env.CONNECTION_STRING}`);
+
+      const results = await connection.primaryKeys(null, `${process.env.DB_SCHEMA}`, 'PKTEST');
+      assert.strictEqual(results.length, 1);
+      assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlPrimaryKeysColumns);
+
+      const result = results[0];
+      // not testing for TABLE_CAT, dependent on the system
+      assert.strictEqual(result.TABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+      assert.strictEqual(result.TABLE_NAME, 'PKTEST');
+      assert.strictEqual(result.COLUMN_NAME, 'ID');
+      await connection.close();
+    });
+    it('...should return information about a primary key with multiple columns.', async () => {
+      const connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const results = await connection.primaryKeys(null, `${process.env.DB_SCHEMA}`, 'MULTIPKTEST');
+
+      assert.strictEqual(results.length, 2);
+      assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlPrimaryKeysColumns);
+
+      let result = results[0];
+      // not testing for TABLE_CAT, dependent on the system
+      assert.strictEqual(result.TABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+      assert.strictEqual(result.TABLE_NAME, 'MULTIPKTEST');
+      assert.strictEqual(result.COLUMN_NAME, 'ID');
+
+      result = results[1];
+      // not testing for TABLE_CAT, dependent on the system
+      assert.strictEqual(result.TABLE_SCHEM, `${process.env.DB_SCHEMA}`);
+      assert.strictEqual(result.TABLE_NAME, 'MULTIPKTEST');
+      assert.strictEqual(result.COLUMN_NAME, 'NUM');
+      await connection.close();
+    });
+    it('...should return empty with bad parameters.', async () => {
+      const connection = await odbc.connect(`${process.env.CONNECTION_STRING}`);
+      const results = await connection.primaryKeys(null, 'bad schema name', 'bad table name');
+
+      assert.strictEqual(results.length, 0);
+      assert.deepStrictEqual(results.columns, global.dbmsConfig.sqlPrimaryKeysColumns);
+      await connection.close();
+    });
+  }); // ...with promises...
+});

--- a/test/statement/execute.test.js
+++ b/test/statement/execute.test.js
@@ -251,7 +251,7 @@ describe('.execute([calback])...', () => {
         });
       });
     });
-    it.only('...should accept a timeout option without crashing', (done) => {
+    it('...should accept a timeout option without crashing', (done) => {
       connection.createStatement((error1, statement) => {
         assert.deepEqual(error1, null);
         assert.notDeepEqual(statement, null);
@@ -383,7 +383,7 @@ describe('.execute([calback])...', () => {
       assert.deepEqual(statementResult[0].AGE, 10);
       await statement.close();
     });
-    it.only('...should accept a timeout option without crashing', async () => {
+    it('...should accept a timeout option without crashing', async () => {
       const statement = await connection.createStatement();
       assert.notDeepEqual(statement, null);
       await statement.prepare(`SELECT * FROM ${process.env.DB_SCHEMA}.${process.env.DB_TABLE}`);


### PR DESCRIPTION
Good ideas coming out of #281. Wrote `primaryKeys` and `foreignKeys` functions for the Connection class. Mostly just copying the existing functionality from the `columns` and `tables` functions.

Ran test suite against it, all passed.

Signed-off-by: Mark Irish <mirish@ibm.com>