### PR TITLE
Improve program dataType(name) access

### DIFF
--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -3,6 +3,7 @@ declare namespace odbc {
   class ColumnDefinition {
     name: string;
     dataType: number;
+    dataTypeName: string;
     columnSize: number;
     decimalDigits: number;
     nullable: boolean;

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -82,10 +82,50 @@ Napi::Value ODBC::Init(Napi::Env env, Napi::Object exports) {
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_PARAM_INPUT_OUTPUT", Napi::Number::New(env, SQL_PARAM_INPUT_OUTPUT), napi_enumerable));
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_PARAM_OUTPUT", Napi::Number::New(env, SQL_PARAM_OUTPUT), napi_enumerable));
 
+  // Export the integer values for each data type so developers can utilize
+  // them programmatically if needed
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_CHAR", Napi::Number::New(env, SQL_CHAR), napi_enumerable));
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_VARCHAR", Napi::Number::New(env, SQL_VARCHAR), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_LONGVARCHAR", Napi::Number::New(env, SQL_LONGVARCHAR), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_WCHAR", Napi::Number::New(env, SQL_WCHAR), napi_enumerable));
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_WVARCHAR", Napi::Number::New(env, SQL_WVARCHAR), napi_enumerable));
-  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTEGER", Napi::Number::New(env, SQL_INTEGER), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_WLONGVARCHAR", Napi::Number::New(env, SQL_WLONGVARCHAR), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_DECIMAL", Napi::Number::New(env, SQL_DECIMAL), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_NUMERIC", Napi::Number::New(env, SQL_NUMERIC), napi_enumerable));
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_SMALLINT", Napi::Number::New(env, SQL_SMALLINT), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTEGER", Napi::Number::New(env, SQL_INTEGER), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_REAL", Napi::Number::New(env, SQL_REAL), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_FLOAT", Napi::Number::New(env, SQL_FLOAT), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_DOUBLE", Napi::Number::New(env, SQL_DOUBLE), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_BIT", Napi::Number::New(env, SQL_BIT), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_TINYINT", Napi::Number::New(env, SQL_TINYINT), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_BIGINT", Napi::Number::New(env, SQL_BIGINT), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_BINARY", Napi::Number::New(env, SQL_BINARY), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_VARBINARY", Napi::Number::New(env, SQL_VARBINARY), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_LONGVARBINARY", Napi::Number::New(env, SQL_LONGVARBINARY), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_TYPE_DATE", Napi::Number::New(env, SQL_TYPE_DATE), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_TYPE_TIME", Napi::Number::New(env, SQL_TYPE_TIME), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_TYPE_TIMESTAMP", Napi::Number::New(env, SQL_TYPE_TIMESTAMP), napi_enumerable));
+  // These are listed in the Microsoft ODBC documentation, but don't appear to
+  // be in unixODBC
+  // ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_TYPE_UTCDATETIME", Napi::Number::New(env, SQL_TYPE_UTCDATETIME), napi_enumerable));
+  // ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_TYPE_UTCTIME", Napi::Number::New(env, SQL_TYPE_UTCTIME), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_MONTH", Napi::Number::New(env, SQL_INTERVAL_MONTH), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_YEAR", Napi::Number::New(env, SQL_INTERVAL_YEAR), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_YEAR_TO_MONTH", Napi::Number::New(env, SQL_INTERVAL_YEAR_TO_MONTH), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_DAY", Napi::Number::New(env, SQL_INTERVAL_DAY), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_HOUR", Napi::Number::New(env, SQL_INTERVAL_HOUR), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_MINUTE", Napi::Number::New(env, SQL_INTERVAL_MINUTE), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_SECOND", Napi::Number::New(env, SQL_INTERVAL_SECOND), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_DAY_TO_HOUR", Napi::Number::New(env, SQL_INTERVAL_DAY_TO_HOUR), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_DAY_TO_MINUTE", Napi::Number::New(env, SQL_INTERVAL_DAY_TO_MINUTE), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_DAY_TO_SECOND", Napi::Number::New(env, SQL_INTERVAL_DAY_TO_SECOND), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_HOUR_TO_MINUTE", Napi::Number::New(env, SQL_INTERVAL_HOUR_TO_MINUTE), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_HOUR_TO_SECOND", Napi::Number::New(env, SQL_INTERVAL_HOUR_TO_SECOND), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_INTERVAL_MINUTE_TO_SECOND", Napi::Number::New(env, SQL_INTERVAL_MINUTE_TO_SECOND), napi_enumerable));
+  ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_GUID", Napi::Number::New(env, SQL_GUID), napi_enumerable));
+  // End data types
+
 
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_NO_NULLS", Napi::Number::New(env, SQL_NO_NULLS), napi_enumerable));
   ODBC_CONSTANTS.push_back(Napi::PropertyDescriptor::Value("SQL_NULLABLE", Napi::Number::New(env, SQL_NULLABLE), napi_enumerable));

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -26,6 +26,7 @@
 // object keys for the result object
 const char* NAME           = "name";
 const char* DATA_TYPE      = "dataType";
+const char* DATA_TYPE_NAME = "dataTypeName";
 const char* COLUMN_SIZE    = "columnSize";
 const char* DECIMAL_DIGITS = "decimalDigits";
 const char* NULLABLE       = "nullable";
@@ -4006,6 +4007,61 @@ fetch_all_and_store
   return return_code;
 }
 
+// This macro and function are used to translate the various ODBC data type
+// macros, returning a string that matches the name of the macro in the ODBC
+// header files. This is then used when returning column data to the user. If
+// the user desires the native (non-ODBC) data type, they should call the
+// columns() function available on the Connection object.
+#define CASE_RETURN_DATA_TYPE_NAME(n) case n: return #n
+
+const char*
+get_odbc_type_name
+(
+  SQLSMALLINT dataType
+)
+{
+  switch(dataType) {
+    CASE_RETURN_DATA_TYPE_NAME(SQL_CHAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_VARCHAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_LONGVARCHAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_WCHAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_WVARCHAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_WLONGVARCHAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_DECIMAL);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_NUMERIC);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_SMALLINT);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTEGER);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_REAL);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_FLOAT);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_DOUBLE);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_BIT);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_TINYINT);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_BIGINT);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_BINARY);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_VARBINARY);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_LONGVARBINARY);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_TYPE_DATE);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_TYPE_TIME);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_TYPE_TIMESTAMP);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_MONTH);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_YEAR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_YEAR_TO_MONTH);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_DAY);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_HOUR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_MINUTE);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_SECOND);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_DAY_TO_HOUR);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_DAY_TO_MINUTE);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_DAY_TO_SECOND);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_HOUR_TO_MINUTE);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_HOUR_TO_SECOND);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_INTERVAL_MINUTE_TO_SECOND);
+    CASE_RETURN_DATA_TYPE_NAME(SQL_GUID);
+
+    default: return "UNKNOWN";
+  }
+}
+
 // All of data has been loaded into data->storedRows. Have to take the data
 // stored in there and convert it it into JavaScript to be given to the
 // Node.js runtime.
@@ -4075,6 +4131,7 @@ Napi::Array process_data_for_napi(Napi::Env env, StatementData *data, Napi::Arra
     column.Set(Napi::String::New(env, NAME), Napi::String::New(env, (const char*)columns[h]->ColumnName));
     #endif
     column.Set(Napi::String::New(env, DATA_TYPE), Napi::Number::New(env, columns[h]->DataType));
+    column.Set(Napi::String::New(env, DATA_TYPE_NAME), Napi::String::New(env, get_odbc_type_name(columns[h]->DataType)));
     column.Set(Napi::String::New(env, COLUMN_SIZE), Napi::Number::New(env, columns[h]->ColumnSize));
     column.Set(Napi::String::New(env, DECIMAL_DIGITS), Napi::Number::New(env, columns[h]->DecimalDigits));
     column.Set(Napi::String::New(env, NULLABLE), Napi::Boolean::New(env, columns[h]->Nullable));


### PR DESCRIPTION
Export all data types on the main package export object.
Return a dataTypeName property on result objects. The new structure of an object in the `columns` property of the return object looks like:

```javascript
{
      name: 'CUSNUM',
      dataType: 2,
      dataTypeName: 'SQL_NUMERIC',
      columnSize: 6,
      decimalDigits: 0,
      nullable: false
    },
    {
      name: 'LSTNAM',
      dataType: 1,
      dataTypeName: 'SQL_CHAR',
      columnSize: 8,
      decimalDigits: 0,
      nullable: false
    }
```

If user's need the _native_ data type name that can be used in SQL statements, instead of the generic ODBC data type name, they can call `.columns` on the connection object, which returns values in the result set like:

```javascript
...
TYPE_NAME: 'NUMERIC'
...
```

Fixes #332