### PR TITLE
Remove `SQL_CURSOR_STATIC` statement attribute from Connection.query

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -742,15 +742,6 @@ class QueryAsyncWorker : public ODBCAsyncWorker {
           return;
         }
 
-        // set SQL_ATTR_CURSOR_TYPE
-        SQLSetStmtAttr
-        (
-          data->hstmt,
-          SQL_ATTR_CURSOR_TYPE,
-          (SQLPOINTER) SQL_CURSOR_STATIC,
-          IGNORED_PARAMETER
-        );
-
         // set SQL_ATTR_QUERY_TIMEOUT
         if (data->query_options.timeout > 0) {
           return_code =

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -370,22 +370,6 @@ class CreateStatementAsyncWorker : public ODBCAsyncWorker {
         SetError("[odbc] Error allocating a handle to create a new Statement\0");
         return;
       }
-
-      // set SQL_ATTR_CURSOR_TYPE
-      return_code =
-      SQLSetStmtAttr
-      (
-        hstmt,
-        SQL_ATTR_CURSOR_TYPE,
-        (SQLPOINTER) SQL_CURSOR_STATIC,
-        IGNORED_PARAMETER
-      );
-
-      if (!SQL_SUCCEEDED(return_code)) {
-        this->errors = GetODBCErrors(SQL_HANDLE_STMT, hstmt);
-        SetError("[odbc] Error setting cursor type on statement.\0");
-        return;
-      }
     }
 
     void OnOK() {


### PR DESCRIPTION
Previously, setting SQL_CURSOR_STATIC was fixed for the prepare/bind/execute workflow, but not for just calling .query. This PR fixes it for calling a Connection's .query as well