### PR TITLE
Tame down stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,9 +1,18 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 14
+
 # Label
 staleLabel: 'stale'
+exemptLabels:
+  - confirmed
+
+# Don't mark issues in projects, milestones, or that are assigned as stale
+exemptProjects: true
+exemptMilestones: true
+exemptAssignees: true
+
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
- Bump from 30 to 90 days
- Add "confirmed" label to keep issue from being marked stale
- Prevent issues being marked stale if they're in projects, milestones, or are assigned

The confirmed label (or whatever we want to call it) will need to be created. Alternatively, we should probably switch to [actions/stale](https://github.com/actions/stale) since Stale Bot is deprecated and unmaintained.