### PR TITLE
Binding from SQL_CHAR to SQL_C_WCHAR instead of SQL_C_CHAR as a build option #292

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,8 @@
       ],
       'defines' : [
         'NAPI_EXPERIMENTAL',
-        'NAPI_VERSION=<(napi_build_version)'
+        'NAPI_VERSION=<(napi_build_version)',
+        'BIND_SQL_CHAR_TO_SQL_C_WCHAR'
       ],
       'conditions' : [
         [ 'OS == "linux"', {


### PR DESCRIPTION
Added the `BIND_SQL_CHAR_TO_SQL_C_WCHAR` define.

This PR addresses the issue #292 