### PR TITLE
Rewrite call procedure

### DIFF
--- a/test/connection/callProcedure.test.js
+++ b/test/connection/callProcedure.test.js
@@ -19,7 +19,6 @@ if (dbms) {
         results = await connection.callProcedure(null, process.env.DB_SCHEMA, procedureName, parameters);
       } catch (error)
       {
-        console.log(error);
         throw(error);
       }
       assert.deepEqual(results.parameters, expectedParams);
@@ -59,7 +58,6 @@ if (dbms) {
                   // await connection.commit();
                 } catch (error) {
                   // In the future, do something more creative with this error
-                  console.log(error);
                   throw(error);
                 }
               });
@@ -75,7 +73,6 @@ if (dbms) {
                   await connection.close();
                 } catch (error) {
                   // In the future, do something more creative with this error
-                  console.log(error);
                   throw(error);
                 }
               });

--- a/test/connection/callProcedure.test.js
+++ b/test/connection/callProcedure.test.js
@@ -14,7 +14,14 @@ if (dbms) {
       const { values } = test;
       const parameters = [values.in.value, values.inout.value, values.out.value];
       const expectedParams = [values.in.expected, values.inout.expected, values.out.expected];
-      const results = await connection.callProcedure(null, process.env.DB_SCHEMA, procedureName, parameters);
+      let results;
+      try {
+        results = await connection.callProcedure(null, process.env.DB_SCHEMA, procedureName, parameters);
+      } catch (error)
+      {
+        console.log(error);
+        throw(error);
+      }
       assert.deepEqual(results.parameters, expectedParams);
     }
 
@@ -52,6 +59,7 @@ if (dbms) {
                   // await connection.commit();
                 } catch (error) {
                   // In the future, do something more creative with this error
+                  console.log(error);
                   throw(error);
                 }
               });
@@ -67,6 +75,7 @@ if (dbms) {
                   await connection.close();
                 } catch (error) {
                   // In the future, do something more creative with this error
+                  console.log(error);
                   throw(error);
                 }
               });


### PR DESCRIPTION
This PR changes the procedure workflow from:

`SQLProcedures` -> `SQLProcedureColumns` -> `SQLExecDirect`

to

`SQLPrepare` -> `SQLDescribeParam` -> `SQLBind` -> `SQLExecDirect`

This will allow users to call a procedure with just the procedure name, even if that procedure exists in multiple schemas/libraries.