### PR TITLE
remove NAPI_EXPERIMENTAL

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,6 @@
         '<!@(node -p "require(\'node-addon-api\').include")'
       ],
       'defines' : [
-        'NAPI_EXPERIMENTAL',
         'NAPI_VERSION=<(napi_build_version)'
       ],
       'conditions' : [
@@ -31,22 +30,22 @@
             [ 'target_arch=="arm64"', {
               'include_dirs': [
                 '/opt/homebrew/include'
-              ],  
+              ],
               'libraries' : [
                 '-L/opt/homebrew/lib',
                 '-lodbc'
-              ],  
+              ],
             }], ['target_arch=="x64"', {
               'include_dirs': [
                 '/usr/local/include',
-              ],  
+              ],
               'libraries' : [
                 '-L/usr/local/lib',
                 '-lodbc'
               ],
             }],
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
         }],
         [ 'OS == "freebsd"', {
           'include_dirs': [
@@ -56,7 +55,7 @@
             '-L/usr/local/lib',
             '-lodbc'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
         }],
         [ 'OS=="win"', {
           'sources' : [
@@ -66,7 +65,7 @@
           'libraries' : [
             '-lodbccp32.lib'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL', 'UNICODE' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'UNICODE' ]
         }],
         [ 'OS=="aix"', {
           'variables': {


### PR DESCRIPTION
As discussed in #380 , I believe the `NAPI_EXPERIMENTAL` flag is causing build issues on supported node versions for this package.

I've looked through the git blame, and it appears that `NAPI_EXPERIMENTAL` was added a number of years ago for `BigInt` support. `BigInt` support was added to node in version 10, and this package says it supports 12, 14, 16 and 18.  

So I think it's safe to remove `NAPI_EXPERIMENTAL` which will fix some failures on node version `18.20+` and other things.

Fixes #380 