### PR TITLE
Add SQL_TXN_* types to TypeScript definition

### DIFF
--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -205,6 +205,11 @@ declare namespace odbc {
 
   function pool(connectionString: string): Promise<Pool>;
   function pool(connectionObject: PoolParameters): Promise<Pool>;
+
+  const SQL_TXN_READ_UNCOMMITTED: number;
+  const SQL_TXN_READ_COMMITTED: number;
+  const SQL_TXN_REPEATABLE_READ: number;
+  const SQL_TXN_SERIALIZABLE: number;
 }
 
 export = odbc;


### PR DESCRIPTION
The odbc object contains transaction isolation level constants that were not included in the TypeScript definition. They could be accessed at runtime but the TypeScript compiler would give a compile-time error.

This commit exposes the following constants (all have type `number`):

* `SQL_TXN_READ_UNCOMMITTED`
* `SQL_TXN_READ_COMMITTED`
* `SQL_TXN_REPEATABLE_READ`
* `SQL_TXN_SERIALIZABLE`

Note that the odbc object also has constants with the full word "transaction" (ex: `SQL_TRANSACTION_READ_UNCOMMITTED`) that have the same value. It also has constants for various SQL types.