### PR TITLE
Return after fail to connect in Pool, else causes unhanded error

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -294,6 +294,7 @@ class Pool {
         this.connect((error, connection) => {
           if (error) {
             reject(error);
+            return;
           }
 
           connection.query(sql, parameters, options, (error, result) => {


### PR DESCRIPTION
Return after fail to connect in Pool, else causes unhanded error.

I came across this error, it was causing the entire process to crash because connection was undefined, pretty obvious I think it should return after reject.

New to contributing to open source, let me know if I'm doing this wrong.