### PR TITLE
Add connected and autocomplete types

### DIFF
--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -143,6 +143,10 @@ declare namespace odbc {
     rollback(): Promise<void>;
 
     close(): Promise<void>;
+
+    connected(): boolean;
+
+    autocommit(): boolean;
   }
 
   class Pool {


### PR DESCRIPTION
This commit adds types to `odbc.d.ts` for the `connected` and `autocomplete` getter methods of the `Connection` object.

Fixes https://github.com/IBM/node-odbc/issues/459