### PR TITLE
ci: GitHub Actions Maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      run: sudo apt install -y unixodbc-dev
+    - name: Install dependencies
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: brew install unixodbc
     - name: Build package

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,6 +22,9 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      run: sudo apt install -y unixodbc-dev
     - name: Install Build Dependencies
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: brew install unixodbc


### PR DESCRIPTION
- Update runners to currently available runners
- Update Node version to 20.x since 18.x is no longer supported
- Update action versions for setup-node