### PR TITLE
chore: Clean up compiler warnings

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -223,9 +223,9 @@ void ODBCAsyncWorker::OnError(const Napi::Error &e) {
     (
       Napi::String::New(env, STATE),
       #ifdef UNICODE
-      Napi::String::New(env, (odbcError.state != NULL) ? (const char16_t*)odbcError.state : (const char16_t*)L"")
+      Napi::String::New(env, (const char16_t *)odbcError.state)
       #else
-      Napi::String::New(env, (odbcError.state != NULL) ? (const char*)odbcError.state : "")
+      Napi::String::New(env, (const char *)odbcError.state)
       #endif
     );
 
@@ -239,9 +239,9 @@ void ODBCAsyncWorker::OnError(const Napi::Error &e) {
     (
       Napi::String::New(env, MESSAGE),
       #ifdef UNICODE
-      Napi::String::New(env, (odbcError.message != NULL) ? (const char16_t *)odbcError.message : (const char16_t *)NO_MSG_TEXT)
+      Napi::String::New(env, (const char16_t *)odbcError.message)
       #else
-      Napi::String::New(env, (odbcError.message != NULL) ? (const char *)odbcError.message : (const char *)NO_MSG_TEXT)
+      Napi::String::New(env, (const char *)odbcError.message)
       #endif
     );
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1242,8 +1242,9 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
 
       #ifndef UNICODE
       char *combinedProcedureName = new char[1024]();
-      sprintf (
+      snprintf (
         combinedProcedureName,
+        1024,
         "%s%s%s%s%s",
         data->catalog ? (const char*)data->catalog : "",
         data->catalog ? "." : "",
@@ -1329,9 +1330,9 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
       if (data->storedRows.size() == 0) {
         char errorString[255];
         #ifndef UNICODE
-        sprintf(errorString, "[odbc] CallProcedureAsyncWorker::Execute: Stored procedure '%s' doesn't exist", combinedProcedureName);
+        snprintf(errorString, sizeof(errorString), "[odbc] CallProcedureAsyncWorker::Execute: Stored procedure '%s' doesn't exist", combinedProcedureName);
         #else
-        sprintf(errorString, "[odbc] CallProcedureAsyncWorker::Execute: Stored procedure '%S' doesn't exist", combinedProcedureName);
+        snprintf(errorString, sizeof(errorString), "[odbc] CallProcedureAsyncWorker::Execute: Stored procedure '%S' doesn't exist", combinedProcedureName);
         #endif
         SetError(errorString);
         return;
@@ -1845,7 +1846,7 @@ class CallProcedureAsyncWorker : public ODBCAsyncWorker {
       size_t sqlStringSize = 1024 + parameterStringSize + sizeof("{ CALL  () }");
       data->sql = new SQLTCHAR[sqlStringSize];
 #ifndef UNICODE
-      sprintf((char *)data->sql, "{ CALL %s (%s) }", combinedProcedureName, parameterString);
+      snprintf((char *)data->sql, sqlStringSize, "{ CALL %s (%s) }", combinedProcedureName, parameterString);
 #else
       // Note: On Windows, %s and %S change their behavior depending on whether
       // it's passed to a printf function or a wprintf function. Since we're passing

--- a/src/odbc_statement.cpp
+++ b/src/odbc_statement.cpp
@@ -95,14 +95,10 @@ SQLRETURN ODBCStatement::Free() {
 class PrepareAsyncWorker : public ODBCAsyncWorker {
 
   private:
-    ODBCStatement  *odbcStatement;
-    ODBCConnection *odbcConnection;
     StatementData  *data;
 
   public:
     PrepareAsyncWorker(ODBCStatement *odbcStatement, Napi::Function& callback) : ODBCAsyncWorker(callback),
-    odbcStatement(odbcStatement),
-    odbcConnection(odbcStatement->odbcConnection),
     data(odbcStatement->data) {}
 
     ~PrepareAsyncWorker() {}
@@ -216,14 +212,9 @@ class BindAsyncWorker : public ODBCAsyncWorker {
   public:
 
     BindAsyncWorker(ODBCStatement *odbcStatement, Napi::Function& callback) : ODBCAsyncWorker(callback),
-    odbcStatement(odbcStatement),
-    odbcConnection(odbcStatement->odbcConnection),
     data(odbcStatement->data) {}
 
   private:
-
-    ODBCStatement  *odbcStatement;
-    ODBCConnection *odbcConnection;
     StatementData  *data;
 
     ~BindAsyncWorker() { }


### PR DESCRIPTION
- odbcError.state will never be NULL
- remove unused class members
- replace sprintf with snprintf