### PR TITLE
ci: Build ppc64le Linux binaries for releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,13 +19,18 @@ jobs:
           - ubuntu-22.04
           - macos-15
           - macos-15-intel
+          - ubuntu-24.04-ppc64le
+        include:
+          - os: ubuntu-24.04-ppc64le
+            arch: ppc64le
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        architecture: ${{ matrix.arch }}
     - name: Install dependencies
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: sudo apt install -y unixodbc-dev


### PR DESCRIPTION
This uses https://github.com/IBM/actionspz to run on self-hosted ppc64le runners.

Fixes #438